### PR TITLE
chore: use 4o context model for inkeep

### DIFF
--- a/src/inkeepApi.ts
+++ b/src/inkeepApi.ts
@@ -18,7 +18,7 @@ export async function docsSearch(apiKey: string, userQuery: string): Promise<str
 			Authorization: `Bearer ${apiKey}`,
 		},
 		body: JSON.stringify({
-			model: "inkeep-rag",
+			model: "inkeep-context-gpt-4o",
 			messages: [{ role: "user", content: userQuery }],
 		}),
 	});


### PR DESCRIPTION
The RAG model outputs too many RAG chunks - use the 4o context model.