### PR TITLE
Added EU support

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,3 @@
 export const DEV = false;
 
-export const BASE_URL = DEV ? "http://localhost:8010" : "https://us.posthog.com";
+export const BASE_URL = process.env.POSTHOG_BASE_URL || (DEV ? "http://localhost:8010" : "https://us.posthog.com");


### PR DESCRIPTION
Added EU support by adding a POSTHOG_BASE_URL optional env argument, allowing https://eu.posthog.com to be used.

Example:
{
  "mcpServers": {
    "posthog": {
      "command": "npx",
      "args": [
        "-y",
        "mcp-remote@latest",
        "https://mcp.posthog.com/sse",
        "--header",
        "Authorization:${POSTHOG_AUTH_HEADER}"
      ],
      "env": {
        "POSTHOG_AUTH_HEADER": "Bearer {YOUR_API_KEY}",
        "POSTHOG_BASE_URL": "https://eu.posthog.com"
      }
    }
  }
}