### PR TITLE
Fix base URL helper

### DIFF
--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -1,5 +1,6 @@
 import { ApiResponseSchema } from "../../schema/api";
 import type { z } from "zod";
+import { BASE_URL } from "../constants";
 
 export const withPagination = async <T>(
 	url: string,
@@ -34,8 +35,8 @@ export const withPagination = async <T>(
 
 export const getProjectBaseUrl = (projectId: string) => {
 	if (projectId === "@current") {
-		return "https://us.posthog.com";
+		return BASE_URL;
 	}
 
-	return `https://us.posthog.com/project/${projectId}`;
+	return `${BASE_URL}/project/${projectId}`;
 };


### PR DESCRIPTION
## Summary
- use BASE_URL constant in getProjectBaseUrl

## Testing
- `npm run format`
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'worker-configuration.d.ts')*


------
https://chatgpt.com/codex/tasks/task_b_68446ad9c408832582a57ac7dd4f45eb