### PR TITLE
feat: pull out tool input schema out and generate json schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ node_modules
 
 # Editor-specific files
 .cursor/
+
+# Python
+__pycache__/

--- a/biome.json
+++ b/biome.json
@@ -4,7 +4,7 @@
 		"enabled": true
 	},
 	"files": {
-		"ignore": ["worker-configuration.d.ts"]
+		"ignore": ["worker-configuration.d.ts", ".mypy_cache/**"]
 	},
 	"vcs": {
 		"enabled": true,

--- a/package.json
+++ b/package.json
@@ -12,17 +12,20 @@
 		"test:watch": "vitest watch",
 		"start": "wrangler dev",
 		"cf-typegen": "wrangler types",
-		"prepare": "husky"
+		"prepare": "husky",
+		"schema:build:json": "tsx scripts/generate-tool-schema.ts"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
 		"@types/node": "^22.15.34",
 		"dotenv": "^16.4.7",
 		"husky": "^9.1.7",
+		"tsx": "^4.20.3",
 		"typescript": "^5.8.3",
 		"vite": "^5.0.0",
 		"vitest": "^3.2.4",
-		"wrangler": "^4.14.4"
+		"wrangler": "^4.14.4",
+		"zod-to-json-schema": "^3.24.6"
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.3
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -48,6 +51,9 @@ importers:
       wrangler:
         specifier: ^4.14.4
         version: 4.16.1(@cloudflare/workers-types@4.20250525.0)
+      zod-to-json-schema:
+        specifier: ^3.24.6
+        version: 3.24.6(zod@3.25.30)
 
 packages:
 
@@ -1052,6 +1058,9 @@ packages:
   get-source@2.0.12:
     resolution: {integrity: sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==}
 
+  get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
@@ -1276,6 +1285,9 @@ packages:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   rollup@4.45.1:
     resolution: {integrity: sha512-4iya7Jb76fVpQyLoiVpzUrsjQ12r3dM7fIVz+4NwoYvZOShknRmiv+iu9CClZml5ZLGb0XMcYLutK6w9tgxHDw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -1409,6 +1421,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.20.3:
+    resolution: {integrity: sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -1555,8 +1572,8 @@ packages:
   youch@3.3.4:
     resolution: {integrity: sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==}
 
-  zod-to-json-schema@3.24.5:
-    resolution: {integrity: sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==}
+  zod-to-json-schema@3.24.6:
+    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
     peerDependencies:
       zod: ^3.24.1
 
@@ -1594,7 +1611,7 @@ snapshots:
       '@ai-sdk/provider': 1.1.3
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.30)
       zod: 3.25.30
-      zod-to-json-schema: 3.24.5(zod@3.25.30)
+      zod-to-json-schema: 3.24.6(zod@3.25.30)
 
   '@biomejs/biome@1.9.4':
     optionalDependencies:
@@ -1909,7 +1926,7 @@ snapshots:
       pkce-challenge: 5.0.0
       raw-body: 3.0.0
       zod: 3.25.30
-      zod-to-json-schema: 3.24.5(zod@3.25.30)
+      zod-to-json-schema: 3.24.6(zod@3.25.30)
     transitivePeerDependencies:
       - supports-color
 
@@ -2399,6 +2416,10 @@ snapshots:
       data-uri-to-buffer: 2.0.2
       source-map: 0.6.1
 
+  get-tsconfig@4.10.1:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   glob-to-regexp@0.4.1: {}
 
   gopd@1.2.0: {}
@@ -2581,6 +2602,8 @@ snapshots:
       unpipe: 1.0.0
 
   react@19.1.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   rollup@4.45.1:
     dependencies:
@@ -2768,6 +2791,13 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
+  tsx@4.20.3:
+    dependencies:
+      esbuild: 0.25.4
+      get-tsconfig: 4.10.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -2914,7 +2944,7 @@ snapshots:
       mustache: 4.2.0
       stacktracey: 2.1.8
 
-  zod-to-json-schema@3.24.5(zod@3.25.30):
+  zod-to-json-schema@3.24.6(zod@3.25.30):
     dependencies:
       zod: 3.25.30
 

--- a/scripts/generate-tool-schema.ts
+++ b/scripts/generate-tool-schema.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env tsx
+
+// Generates JSON schema from Zod tool-inputs schemas for Python Pydantic schema generation
+
+import * as fs from "node:fs";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import * as schemas from "../src/schema/tool-inputs";
+
+const output_path = "src/schema/tool-inputs.json";
+
+console.log("Generating JSON schema from Zod tool-inputs schemas...");
+
+try {
+	// Convert all Zod schemas to JSON Schema
+	const jsonSchemas = {
+		$schema: "http://json-schema.org/draft-07/schema#",
+		definitions: {} as Record<string, any>,
+	};
+
+	// Add each schema to the definitions
+	for (const [schemaName, zodSchema] of Object.entries(schemas)) {
+		if (schemaName.endsWith("Schema")) {
+			console.log(`Converting ${schemaName}...`);
+			const jsonSchema = zodToJsonSchema(zodSchema, {
+				name: schemaName,
+				$refStrategy: "none",
+			});
+
+			// Remove the top-level $schema to avoid conflicts
+			jsonSchema.$schema = undefined;
+
+			jsonSchemas.definitions[schemaName] = jsonSchema;
+		}
+	}
+
+	// Write the combined schema
+	const schemaString = JSON.stringify(jsonSchemas, null, 2);
+	fs.writeFileSync(output_path, schemaString);
+
+	console.log(`✅ JSON schema generated successfully at: ${output_path}`);
+	console.log(
+		`📋 Generated schemas for ${Object.keys(jsonSchemas.definitions).length} tool input types`,
+	);
+} catch (err) {
+	console.error("❌ Error generating schema:", err);
+	process.exit(1);
+}

--- a/src/schema/tool-inputs.json
+++ b/src/schema/tool-inputs.json
@@ -1,909 +1,819 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "definitions": {
-    "DashboardAddInsightSchema": {
-      "$ref": "#/definitions/DashboardAddInsightSchema",
-      "definitions": {
-        "DashboardAddInsightSchema": {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "insight_id": {
-                  "type": "integer",
-                  "exclusiveMinimum": 0
-                },
-                "dashboard_id": {
-                  "type": "integer",
-                  "exclusiveMinimum": 0
-                }
-              },
-              "required": [
-                "insight_id",
-                "dashboard_id"
-              ],
-              "additionalProperties": false
-            }
-          },
-          "required": [
-            "data"
-          ],
-          "additionalProperties": false
-        }
-      }
-    },
-    "DashboardCreateSchema": {
-      "$ref": "#/definitions/DashboardCreateSchema",
-      "definitions": {
-        "DashboardCreateSchema": {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "description": {
-                  "type": "string"
-                },
-                "pinned": {
-                  "type": "boolean",
-                  "default": false
-                },
-                "tags": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              },
-              "required": [
-                "name"
-              ],
-              "additionalProperties": false
-            }
-          },
-          "required": [
-            "data"
-          ],
-          "additionalProperties": false
-        }
-      }
-    },
-    "DashboardDeleteSchema": {
-      "$ref": "#/definitions/DashboardDeleteSchema",
-      "definitions": {
-        "DashboardDeleteSchema": {
-          "type": "object",
-          "properties": {
-            "dashboardId": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "dashboardId"
-          ],
-          "additionalProperties": false
-        }
-      }
-    },
-    "DashboardGetAllSchema": {
-      "$ref": "#/definitions/DashboardGetAllSchema",
-      "definitions": {
-        "DashboardGetAllSchema": {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "limit": {
-                  "type": "integer",
-                  "exclusiveMinimum": 0
-                },
-                "offset": {
-                  "type": "integer",
-                  "minimum": 0
-                },
-                "search": {
-                  "type": "string"
-                },
-                "pinned": {
-                  "type": "boolean"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        }
-      }
-    },
-    "DashboardGetSchema": {
-      "$ref": "#/definitions/DashboardGetSchema",
-      "definitions": {
-        "DashboardGetSchema": {
-          "type": "object",
-          "properties": {
-            "dashboardId": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "dashboardId"
-          ],
-          "additionalProperties": false
-        }
-      }
-    },
-    "DashboardUpdateSchema": {
-      "$ref": "#/definitions/DashboardUpdateSchema",
-      "definitions": {
-        "DashboardUpdateSchema": {
-          "type": "object",
-          "properties": {
-            "dashboardId": {
-              "type": "number"
-            },
-            "data": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "pinned": {
-                  "type": "boolean"
-                },
-                "tags": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "required": [
-            "dashboardId",
-            "data"
-          ],
-          "additionalProperties": false
-        }
-      }
-    },
-    "DocumentationSearchSchema": {
-      "$ref": "#/definitions/DocumentationSearchSchema",
-      "definitions": {
-        "DocumentationSearchSchema": {
-          "type": "object",
-          "properties": {
-            "query": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "query"
-          ],
-          "additionalProperties": false
-        }
-      }
-    },
-    "ErrorTrackingDetailsSchema": {
-      "$ref": "#/definitions/ErrorTrackingDetailsSchema",
-      "definitions": {
-        "ErrorTrackingDetailsSchema": {
-          "type": "object",
-          "properties": {
-            "issueId": {
-              "type": "string",
-              "format": "uuid"
-            },
-            "dateFrom": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "dateTo": {
-              "type": "string",
-              "format": "date-time"
-            }
-          },
-          "required": [
-            "issueId"
-          ],
-          "additionalProperties": false
-        }
-      }
-    },
-    "ErrorTrackingListSchema": {
-      "$ref": "#/definitions/ErrorTrackingListSchema",
-      "definitions": {
-        "ErrorTrackingListSchema": {
-          "type": "object",
-          "properties": {
-            "orderBy": {
-              "type": "string",
-              "enum": [
-                "occurrences",
-                "first_seen",
-                "last_seen",
-                "users",
-                "sessions"
-              ]
-            },
-            "dateFrom": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "dateTo": {
-              "type": "string",
-              "format": "date-time"
-            },
-            "orderDirection": {
-              "type": "string",
-              "enum": [
-                "ASC",
-                "DESC"
-              ]
-            },
-            "filterTestAccounts": {
-              "type": "boolean"
-            },
-            "status": {
-              "type": "string",
-              "enum": [
-                "active",
-                "resolved",
-                "all",
-                "suppressed"
-              ]
-            }
-          },
-          "additionalProperties": false
-        }
-      }
-    },
-    "FeatureFlagCreateSchema": {
-      "$ref": "#/definitions/FeatureFlagCreateSchema",
-      "definitions": {
-        "FeatureFlagCreateSchema": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string"
-            },
-            "key": {
-              "type": "string"
-            },
-            "description": {
-              "type": "string"
-            },
-            "filters": {
-              "type": "object",
-              "properties": {
-                "groups": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "properties": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "key": {
-                              "type": "string"
-                            },
-                            "value": {
-                              "anyOf": [
-                                {
-                                  "type": "string"
-                                },
-                                {
-                                  "type": "number"
-                                },
-                                {
-                                  "type": "boolean"
-                                },
-                                {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string"
-                                  }
-                                },
-                                {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "number"
-                                  }
-                                }
-                              ]
-                            },
-                            "operator": {
-                              "type": "string",
-                              "enum": [
-                                "exact",
-                                "is_not",
-                                "icontains",
-                                "not_icontains",
-                                "regex",
-                                "not_regex",
-                                "is_cleaned_path_exact",
-                                "exact",
-                                "is_not",
-                                "gt",
-                                "gte",
-                                "lt",
-                                "lte",
-                                "min",
-                                "max",
-                                "exact",
-                                "is_not",
-                                "in",
-                                "not_in"
-                              ]
-                            }
-                          },
-                          "required": [
-                            "key",
-                            "value"
-                          ],
-                          "additionalProperties": false
-                        }
-                      },
-                      "rollout_percentage": {
-                        "type": "number"
-                      }
-                    },
-                    "required": [
-                      "properties",
-                      "rollout_percentage"
-                    ],
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "required": [
-                "groups"
-              ],
-              "additionalProperties": false
-            },
-            "active": {
-              "type": "boolean"
-            },
-            "tags": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          },
-          "required": [
-            "name",
-            "key",
-            "description",
-            "filters",
-            "active"
-          ],
-          "additionalProperties": false
-        }
-      }
-    },
-    "FeatureFlagDeleteSchema": {
-      "$ref": "#/definitions/FeatureFlagDeleteSchema",
-      "definitions": {
-        "FeatureFlagDeleteSchema": {
-          "type": "object",
-          "properties": {
-            "flagKey": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "flagKey"
-          ],
-          "additionalProperties": false
-        }
-      }
-    },
-    "FeatureFlagGetAllSchema": {
-      "$ref": "#/definitions/FeatureFlagGetAllSchema",
-      "definitions": {
-        "FeatureFlagGetAllSchema": {
-          "type": "object",
-          "properties": {},
-          "additionalProperties": false
-        }
-      }
-    },
-    "FeatureFlagGetDefinitionSchema": {
-      "$ref": "#/definitions/FeatureFlagGetDefinitionSchema",
-      "definitions": {
-        "FeatureFlagGetDefinitionSchema": {
-          "type": "object",
-          "properties": {
-            "flagId": {
-              "type": "integer",
-              "exclusiveMinimum": 0
-            },
-            "flagKey": {
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
-        }
-      }
-    },
-    "FeatureFlagUpdateSchema": {
-      "$ref": "#/definitions/FeatureFlagUpdateSchema",
-      "definitions": {
-        "FeatureFlagUpdateSchema": {
-          "type": "object",
-          "properties": {
-            "flagKey": {
-              "type": "string"
-            },
-            "data": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "filters": {
-                  "type": "object",
-                  "properties": {
-                    "groups": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "properties": {
-                            "type": "array",
-                            "items": {
-                              "type": "object",
-                              "properties": {
-                                "key": {
-                                  "type": "string"
-                                },
-                                "value": {
-                                  "anyOf": [
-                                    {
-                                      "type": "string"
-                                    },
-                                    {
-                                      "type": "number"
-                                    },
-                                    {
-                                      "type": "boolean"
-                                    },
-                                    {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "string"
-                                      }
-                                    },
-                                    {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "number"
-                                      }
-                                    }
-                                  ]
-                                },
-                                "operator": {
-                                  "type": "string",
-                                  "enum": [
-                                    "exact",
-                                    "is_not",
-                                    "icontains",
-                                    "not_icontains",
-                                    "regex",
-                                    "not_regex",
-                                    "is_cleaned_path_exact",
-                                    "exact",
-                                    "is_not",
-                                    "gt",
-                                    "gte",
-                                    "lt",
-                                    "lte",
-                                    "min",
-                                    "max",
-                                    "exact",
-                                    "is_not",
-                                    "in",
-                                    "not_in"
-                                  ]
-                                }
-                              },
-                              "required": [
-                                "key",
-                                "value"
-                              ],
-                              "additionalProperties": false
-                            }
-                          },
-                          "rollout_percentage": {
-                            "type": "number"
-                          }
-                        },
-                        "required": [
-                          "properties",
-                          "rollout_percentage"
-                        ],
-                        "additionalProperties": false
-                      }
-                    }
-                  },
-                  "required": [
-                    "groups"
-                  ],
-                  "additionalProperties": false
-                },
-                "active": {
-                  "type": "boolean"
-                },
-                "tags": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "required": [
-            "flagKey",
-            "data"
-          ],
-          "additionalProperties": false
-        }
-      }
-    },
-    "InsightCreateSchema": {
-      "$ref": "#/definitions/InsightCreateSchema",
-      "definitions": {
-        "InsightCreateSchema": {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "query": {
-                  "type": "object",
-                  "properties": {
-                    "kind": {
-                      "type": "string",
-                      "const": "DataVisualizationNode"
-                    },
-                    "source": {
-                      "type": "object",
-                      "properties": {
-                        "kind": {
-                          "type": "string",
-                          "const": "HogQLQuery"
-                        },
-                        "query": {
-                          "type": "string"
-                        },
-                        "explain": {
-                          "type": "boolean"
-                        },
-                        "filters": {
-                          "type": "object",
-                          "properties": {
-                            "dateRange": {
-                              "type": "object",
-                              "properties": {
-                                "date_from": {
-                                  "type": "string",
-                                  "description": "The start date of the date range. Could be a date string or a relative date string like '-7d'"
-                                },
-                                "date_to": {
-                                  "type": "string",
-                                  "description": "The end date of the date range. Could be a date string or a relative date string like '-1d'"
-                                }
-                              },
-                              "required": [
-                                "date_from",
-                                "date_to"
-                              ],
-                              "additionalProperties": false
-                            }
-                          },
-                          "additionalProperties": false
-                        }
-                      },
-                      "required": [
-                        "kind",
-                        "query"
-                      ],
-                      "additionalProperties": false
-                    }
-                  },
-                  "required": [
-                    "kind",
-                    "source"
-                  ],
-                  "additionalProperties": false
-                },
-                "description": {
-                  "type": "string"
-                },
-                "saved": {
-                  "type": "boolean",
-                  "default": true
-                },
-                "favorited": {
-                  "type": "boolean",
-                  "default": false
-                },
-                "tags": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              },
-              "required": [
-                "name",
-                "query"
-              ],
-              "additionalProperties": false
-            }
-          },
-          "required": [
-            "data"
-          ],
-          "additionalProperties": false
-        }
-      }
-    },
-    "InsightDeleteSchema": {
-      "$ref": "#/definitions/InsightDeleteSchema",
-      "definitions": {
-        "InsightDeleteSchema": {
-          "type": "object",
-          "properties": {
-            "insightId": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "insightId"
-          ],
-          "additionalProperties": false
-        }
-      }
-    },
-    "InsightGetAllSchema": {
-      "$ref": "#/definitions/InsightGetAllSchema",
-      "definitions": {
-        "InsightGetAllSchema": {
-          "type": "object",
-          "properties": {
-            "data": {
-              "type": "object",
-              "properties": {
-                "limit": {
-                  "type": "number"
-                },
-                "offset": {
-                  "type": "number"
-                },
-                "saved": {
-                  "type": "boolean"
-                },
-                "favorited": {
-                  "type": "boolean"
-                },
-                "search": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        }
-      }
-    },
-    "InsightGetSchema": {
-      "$ref": "#/definitions/InsightGetSchema",
-      "definitions": {
-        "InsightGetSchema": {
-          "type": "object",
-          "properties": {
-            "insightId": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "insightId"
-          ],
-          "additionalProperties": false
-        }
-      }
-    },
-    "InsightGetSqlSchema": {
-      "$ref": "#/definitions/InsightGetSqlSchema",
-      "definitions": {
-        "InsightGetSqlSchema": {
-          "type": "object",
-          "properties": {
-            "query": {
-              "type": "string",
-              "maxLength": 1000,
-              "description": "Your natural language query describing the SQL insight (max 1000 characters)."
-            }
-          },
-          "required": [
-            "query"
-          ],
-          "additionalProperties": false
-        }
-      }
-    },
-    "InsightUpdateSchema": {
-      "$ref": "#/definitions/InsightUpdateSchema",
-      "definitions": {
-        "InsightUpdateSchema": {
-          "type": "object",
-          "properties": {
-            "insightId": {
-              "type": "number"
-            },
-            "data": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "description": {
-                  "type": "string"
-                },
-                "filters": {
-                  "type": "object",
-                  "additionalProperties": {}
-                },
-                "query": {
-                  "type": "object",
-                  "additionalProperties": {}
-                },
-                "saved": {
-                  "type": "boolean"
-                },
-                "favorited": {
-                  "type": "boolean"
-                },
-                "dashboard": {
-                  "type": "number"
-                },
-                "tags": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
-                  }
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "required": [
-            "insightId",
-            "data"
-          ],
-          "additionalProperties": false
-        }
-      }
-    },
-    "LLMObservabilityGetCostsSchema": {
-      "$ref": "#/definitions/LLMObservabilityGetCostsSchema",
-      "definitions": {
-        "LLMObservabilityGetCostsSchema": {
-          "type": "object",
-          "properties": {
-            "projectId": {
-              "type": "integer",
-              "exclusiveMinimum": 0
-            },
-            "days": {
-              "type": "number"
-            }
-          },
-          "required": [
-            "projectId"
-          ],
-          "additionalProperties": false
-        }
-      }
-    },
-    "OrganizationGetAllSchema": {
-      "$ref": "#/definitions/OrganizationGetAllSchema",
-      "definitions": {
-        "OrganizationGetAllSchema": {
-          "type": "object",
-          "properties": {},
-          "additionalProperties": false
-        }
-      }
-    },
-    "OrganizationGetDetailsSchema": {
-      "$ref": "#/definitions/OrganizationGetDetailsSchema",
-      "definitions": {
-        "OrganizationGetDetailsSchema": {
-          "type": "object",
-          "properties": {},
-          "additionalProperties": false
-        }
-      }
-    },
-    "OrganizationSetActiveSchema": {
-      "$ref": "#/definitions/OrganizationSetActiveSchema",
-      "definitions": {
-        "OrganizationSetActiveSchema": {
-          "type": "object",
-          "properties": {
-            "orgId": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          "required": [
-            "orgId"
-          ],
-          "additionalProperties": false
-        }
-      }
-    },
-    "ProjectGetAllSchema": {
-      "$ref": "#/definitions/ProjectGetAllSchema",
-      "definitions": {
-        "ProjectGetAllSchema": {
-          "type": "object",
-          "properties": {},
-          "additionalProperties": false
-        }
-      }
-    },
-    "ProjectPropertyDefinitionsSchema": {
-      "$ref": "#/definitions/ProjectPropertyDefinitionsSchema",
-      "definitions": {
-        "ProjectPropertyDefinitionsSchema": {
-          "type": "object",
-          "properties": {},
-          "additionalProperties": false
-        }
-      }
-    },
-    "ProjectSetActiveSchema": {
-      "$ref": "#/definitions/ProjectSetActiveSchema",
-      "definitions": {
-        "ProjectSetActiveSchema": {
-          "type": "object",
-          "properties": {
-            "projectId": {
-              "type": "integer",
-              "exclusiveMinimum": 0
-            }
-          },
-          "required": [
-            "projectId"
-          ],
-          "additionalProperties": false
-        }
-      }
-    }
-  }
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"definitions": {
+		"DashboardAddInsightSchema": {
+			"$ref": "#/definitions/DashboardAddInsightSchema",
+			"definitions": {
+				"DashboardAddInsightSchema": {
+					"type": "object",
+					"properties": {
+						"data": {
+							"type": "object",
+							"properties": {
+								"insight_id": {
+									"type": "integer",
+									"exclusiveMinimum": 0
+								},
+								"dashboard_id": {
+									"type": "integer",
+									"exclusiveMinimum": 0
+								}
+							},
+							"required": ["insight_id", "dashboard_id"],
+							"additionalProperties": false
+						}
+					},
+					"required": ["data"],
+					"additionalProperties": false
+				}
+			}
+		},
+		"DashboardCreateSchema": {
+			"$ref": "#/definitions/DashboardCreateSchema",
+			"definitions": {
+				"DashboardCreateSchema": {
+					"type": "object",
+					"properties": {
+						"data": {
+							"type": "object",
+							"properties": {
+								"name": {
+									"type": "string",
+									"minLength": 1
+								},
+								"description": {
+									"type": "string"
+								},
+								"pinned": {
+									"type": "boolean",
+									"default": false
+								},
+								"tags": {
+									"type": "array",
+									"items": {
+										"type": "string"
+									}
+								}
+							},
+							"required": ["name"],
+							"additionalProperties": false
+						}
+					},
+					"required": ["data"],
+					"additionalProperties": false
+				}
+			}
+		},
+		"DashboardDeleteSchema": {
+			"$ref": "#/definitions/DashboardDeleteSchema",
+			"definitions": {
+				"DashboardDeleteSchema": {
+					"type": "object",
+					"properties": {
+						"dashboardId": {
+							"type": "number"
+						}
+					},
+					"required": ["dashboardId"],
+					"additionalProperties": false
+				}
+			}
+		},
+		"DashboardGetAllSchema": {
+			"$ref": "#/definitions/DashboardGetAllSchema",
+			"definitions": {
+				"DashboardGetAllSchema": {
+					"type": "object",
+					"properties": {
+						"data": {
+							"type": "object",
+							"properties": {
+								"limit": {
+									"type": "integer",
+									"exclusiveMinimum": 0
+								},
+								"offset": {
+									"type": "integer",
+									"minimum": 0
+								},
+								"search": {
+									"type": "string"
+								},
+								"pinned": {
+									"type": "boolean"
+								}
+							},
+							"additionalProperties": false
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"DashboardGetSchema": {
+			"$ref": "#/definitions/DashboardGetSchema",
+			"definitions": {
+				"DashboardGetSchema": {
+					"type": "object",
+					"properties": {
+						"dashboardId": {
+							"type": "number"
+						}
+					},
+					"required": ["dashboardId"],
+					"additionalProperties": false
+				}
+			}
+		},
+		"DashboardUpdateSchema": {
+			"$ref": "#/definitions/DashboardUpdateSchema",
+			"definitions": {
+				"DashboardUpdateSchema": {
+					"type": "object",
+					"properties": {
+						"dashboardId": {
+							"type": "number"
+						},
+						"data": {
+							"type": "object",
+							"properties": {
+								"name": {
+									"type": "string"
+								},
+								"description": {
+									"type": "string"
+								},
+								"pinned": {
+									"type": "boolean"
+								},
+								"tags": {
+									"type": "array",
+									"items": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						}
+					},
+					"required": ["dashboardId", "data"],
+					"additionalProperties": false
+				}
+			}
+		},
+		"DocumentationSearchSchema": {
+			"$ref": "#/definitions/DocumentationSearchSchema",
+			"definitions": {
+				"DocumentationSearchSchema": {
+					"type": "object",
+					"properties": {
+						"query": {
+							"type": "string"
+						}
+					},
+					"required": ["query"],
+					"additionalProperties": false
+				}
+			}
+		},
+		"ErrorTrackingDetailsSchema": {
+			"$ref": "#/definitions/ErrorTrackingDetailsSchema",
+			"definitions": {
+				"ErrorTrackingDetailsSchema": {
+					"type": "object",
+					"properties": {
+						"issueId": {
+							"type": "string",
+							"format": "uuid"
+						},
+						"dateFrom": {
+							"type": "string",
+							"format": "date-time"
+						},
+						"dateTo": {
+							"type": "string",
+							"format": "date-time"
+						}
+					},
+					"required": ["issueId"],
+					"additionalProperties": false
+				}
+			}
+		},
+		"ErrorTrackingListSchema": {
+			"$ref": "#/definitions/ErrorTrackingListSchema",
+			"definitions": {
+				"ErrorTrackingListSchema": {
+					"type": "object",
+					"properties": {
+						"orderBy": {
+							"type": "string",
+							"enum": ["occurrences", "first_seen", "last_seen", "users", "sessions"]
+						},
+						"dateFrom": {
+							"type": "string",
+							"format": "date-time"
+						},
+						"dateTo": {
+							"type": "string",
+							"format": "date-time"
+						},
+						"orderDirection": {
+							"type": "string",
+							"enum": ["ASC", "DESC"]
+						},
+						"filterTestAccounts": {
+							"type": "boolean"
+						},
+						"status": {
+							"type": "string",
+							"enum": ["active", "resolved", "all", "suppressed"]
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"FeatureFlagCreateSchema": {
+			"$ref": "#/definitions/FeatureFlagCreateSchema",
+			"definitions": {
+				"FeatureFlagCreateSchema": {
+					"type": "object",
+					"properties": {
+						"name": {
+							"type": "string"
+						},
+						"key": {
+							"type": "string"
+						},
+						"description": {
+							"type": "string"
+						},
+						"filters": {
+							"type": "object",
+							"properties": {
+								"groups": {
+									"type": "array",
+									"items": {
+										"type": "object",
+										"properties": {
+											"properties": {
+												"type": "array",
+												"items": {
+													"type": "object",
+													"properties": {
+														"key": {
+															"type": "string"
+														},
+														"value": {
+															"anyOf": [
+																{
+																	"type": "string"
+																},
+																{
+																	"type": "number"
+																},
+																{
+																	"type": "boolean"
+																},
+																{
+																	"type": "array",
+																	"items": {
+																		"type": "string"
+																	}
+																},
+																{
+																	"type": "array",
+																	"items": {
+																		"type": "number"
+																	}
+																}
+															]
+														},
+														"operator": {
+															"type": "string",
+															"enum": [
+																"exact",
+																"is_not",
+																"icontains",
+																"not_icontains",
+																"regex",
+																"not_regex",
+																"is_cleaned_path_exact",
+																"exact",
+																"is_not",
+																"gt",
+																"gte",
+																"lt",
+																"lte",
+																"min",
+																"max",
+																"exact",
+																"is_not",
+																"in",
+																"not_in"
+															]
+														}
+													},
+													"required": ["key", "value"],
+													"additionalProperties": false
+												}
+											},
+											"rollout_percentage": {
+												"type": "number"
+											}
+										},
+										"required": ["properties", "rollout_percentage"],
+										"additionalProperties": false
+									}
+								}
+							},
+							"required": ["groups"],
+							"additionalProperties": false
+						},
+						"active": {
+							"type": "boolean"
+						},
+						"tags": {
+							"type": "array",
+							"items": {
+								"type": "string"
+							}
+						}
+					},
+					"required": ["name", "key", "description", "filters", "active"],
+					"additionalProperties": false
+				}
+			}
+		},
+		"FeatureFlagDeleteSchema": {
+			"$ref": "#/definitions/FeatureFlagDeleteSchema",
+			"definitions": {
+				"FeatureFlagDeleteSchema": {
+					"type": "object",
+					"properties": {
+						"flagKey": {
+							"type": "string"
+						}
+					},
+					"required": ["flagKey"],
+					"additionalProperties": false
+				}
+			}
+		},
+		"FeatureFlagGetAllSchema": {
+			"$ref": "#/definitions/FeatureFlagGetAllSchema",
+			"definitions": {
+				"FeatureFlagGetAllSchema": {
+					"type": "object",
+					"properties": {},
+					"additionalProperties": false
+				}
+			}
+		},
+		"FeatureFlagGetDefinitionSchema": {
+			"$ref": "#/definitions/FeatureFlagGetDefinitionSchema",
+			"definitions": {
+				"FeatureFlagGetDefinitionSchema": {
+					"type": "object",
+					"properties": {
+						"flagId": {
+							"type": "integer",
+							"exclusiveMinimum": 0
+						},
+						"flagKey": {
+							"type": "string"
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"FeatureFlagUpdateSchema": {
+			"$ref": "#/definitions/FeatureFlagUpdateSchema",
+			"definitions": {
+				"FeatureFlagUpdateSchema": {
+					"type": "object",
+					"properties": {
+						"flagKey": {
+							"type": "string"
+						},
+						"data": {
+							"type": "object",
+							"properties": {
+								"name": {
+									"type": "string"
+								},
+								"description": {
+									"type": "string"
+								},
+								"filters": {
+									"type": "object",
+									"properties": {
+										"groups": {
+											"type": "array",
+											"items": {
+												"type": "object",
+												"properties": {
+													"properties": {
+														"type": "array",
+														"items": {
+															"type": "object",
+															"properties": {
+																"key": {
+																	"type": "string"
+																},
+																"value": {
+																	"anyOf": [
+																		{
+																			"type": "string"
+																		},
+																		{
+																			"type": "number"
+																		},
+																		{
+																			"type": "boolean"
+																		},
+																		{
+																			"type": "array",
+																			"items": {
+																				"type": "string"
+																			}
+																		},
+																		{
+																			"type": "array",
+																			"items": {
+																				"type": "number"
+																			}
+																		}
+																	]
+																},
+																"operator": {
+																	"type": "string",
+																	"enum": [
+																		"exact",
+																		"is_not",
+																		"icontains",
+																		"not_icontains",
+																		"regex",
+																		"not_regex",
+																		"is_cleaned_path_exact",
+																		"exact",
+																		"is_not",
+																		"gt",
+																		"gte",
+																		"lt",
+																		"lte",
+																		"min",
+																		"max",
+																		"exact",
+																		"is_not",
+																		"in",
+																		"not_in"
+																	]
+																}
+															},
+															"required": ["key", "value"],
+															"additionalProperties": false
+														}
+													},
+													"rollout_percentage": {
+														"type": "number"
+													}
+												},
+												"required": ["properties", "rollout_percentage"],
+												"additionalProperties": false
+											}
+										}
+									},
+									"required": ["groups"],
+									"additionalProperties": false
+								},
+								"active": {
+									"type": "boolean"
+								},
+								"tags": {
+									"type": "array",
+									"items": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						}
+					},
+					"required": ["flagKey", "data"],
+					"additionalProperties": false
+				}
+			}
+		},
+		"InsightCreateSchema": {
+			"$ref": "#/definitions/InsightCreateSchema",
+			"definitions": {
+				"InsightCreateSchema": {
+					"type": "object",
+					"properties": {
+						"data": {
+							"type": "object",
+							"properties": {
+								"name": {
+									"type": "string"
+								},
+								"query": {
+									"type": "object",
+									"properties": {
+										"kind": {
+											"type": "string",
+											"const": "DataVisualizationNode"
+										},
+										"source": {
+											"type": "object",
+											"properties": {
+												"kind": {
+													"type": "string",
+													"const": "HogQLQuery"
+												},
+												"query": {
+													"type": "string"
+												},
+												"explain": {
+													"type": "boolean"
+												},
+												"filters": {
+													"type": "object",
+													"properties": {
+														"dateRange": {
+															"type": "object",
+															"properties": {
+																"date_from": {
+																	"type": "string",
+																	"description": "The start date of the date range. Could be a date string or a relative date string like '-7d'"
+																},
+																"date_to": {
+																	"type": "string",
+																	"description": "The end date of the date range. Could be a date string or a relative date string like '-1d'"
+																}
+															},
+															"required": ["date_from", "date_to"],
+															"additionalProperties": false
+														}
+													},
+													"additionalProperties": false
+												}
+											},
+											"required": ["kind", "query"],
+											"additionalProperties": false
+										}
+									},
+									"required": ["kind", "source"],
+									"additionalProperties": false
+								},
+								"description": {
+									"type": "string"
+								},
+								"saved": {
+									"type": "boolean",
+									"default": true
+								},
+								"favorited": {
+									"type": "boolean",
+									"default": false
+								},
+								"tags": {
+									"type": "array",
+									"items": {
+										"type": "string"
+									}
+								}
+							},
+							"required": ["name", "query"],
+							"additionalProperties": false
+						}
+					},
+					"required": ["data"],
+					"additionalProperties": false
+				}
+			}
+		},
+		"InsightDeleteSchema": {
+			"$ref": "#/definitions/InsightDeleteSchema",
+			"definitions": {
+				"InsightDeleteSchema": {
+					"type": "object",
+					"properties": {
+						"insightId": {
+							"type": "number"
+						}
+					},
+					"required": ["insightId"],
+					"additionalProperties": false
+				}
+			}
+		},
+		"InsightGetAllSchema": {
+			"$ref": "#/definitions/InsightGetAllSchema",
+			"definitions": {
+				"InsightGetAllSchema": {
+					"type": "object",
+					"properties": {
+						"data": {
+							"type": "object",
+							"properties": {
+								"limit": {
+									"type": "number"
+								},
+								"offset": {
+									"type": "number"
+								},
+								"saved": {
+									"type": "boolean"
+								},
+								"favorited": {
+									"type": "boolean"
+								},
+								"search": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"InsightGetSchema": {
+			"$ref": "#/definitions/InsightGetSchema",
+			"definitions": {
+				"InsightGetSchema": {
+					"type": "object",
+					"properties": {
+						"insightId": {
+							"type": "number"
+						}
+					},
+					"required": ["insightId"],
+					"additionalProperties": false
+				}
+			}
+		},
+		"InsightGetSqlSchema": {
+			"$ref": "#/definitions/InsightGetSqlSchema",
+			"definitions": {
+				"InsightGetSqlSchema": {
+					"type": "object",
+					"properties": {
+						"query": {
+							"type": "string",
+							"maxLength": 1000,
+							"description": "Your natural language query describing the SQL insight (max 1000 characters)."
+						}
+					},
+					"required": ["query"],
+					"additionalProperties": false
+				}
+			}
+		},
+		"InsightUpdateSchema": {
+			"$ref": "#/definitions/InsightUpdateSchema",
+			"definitions": {
+				"InsightUpdateSchema": {
+					"type": "object",
+					"properties": {
+						"insightId": {
+							"type": "number"
+						},
+						"data": {
+							"type": "object",
+							"properties": {
+								"name": {
+									"type": "string"
+								},
+								"description": {
+									"type": "string"
+								},
+								"filters": {
+									"type": "object",
+									"additionalProperties": {}
+								},
+								"query": {
+									"type": "object",
+									"additionalProperties": {}
+								},
+								"saved": {
+									"type": "boolean"
+								},
+								"favorited": {
+									"type": "boolean"
+								},
+								"dashboard": {
+									"type": "number"
+								},
+								"tags": {
+									"type": "array",
+									"items": {
+										"type": "string"
+									}
+								}
+							},
+							"additionalProperties": false
+						}
+					},
+					"required": ["insightId", "data"],
+					"additionalProperties": false
+				}
+			}
+		},
+		"LLMObservabilityGetCostsSchema": {
+			"$ref": "#/definitions/LLMObservabilityGetCostsSchema",
+			"definitions": {
+				"LLMObservabilityGetCostsSchema": {
+					"type": "object",
+					"properties": {
+						"projectId": {
+							"type": "integer",
+							"exclusiveMinimum": 0
+						},
+						"days": {
+							"type": "number"
+						}
+					},
+					"required": ["projectId"],
+					"additionalProperties": false
+				}
+			}
+		},
+		"OrganizationGetAllSchema": {
+			"$ref": "#/definitions/OrganizationGetAllSchema",
+			"definitions": {
+				"OrganizationGetAllSchema": {
+					"type": "object",
+					"properties": {},
+					"additionalProperties": false
+				}
+			}
+		},
+		"OrganizationGetDetailsSchema": {
+			"$ref": "#/definitions/OrganizationGetDetailsSchema",
+			"definitions": {
+				"OrganizationGetDetailsSchema": {
+					"type": "object",
+					"properties": {},
+					"additionalProperties": false
+				}
+			}
+		},
+		"OrganizationSetActiveSchema": {
+			"$ref": "#/definitions/OrganizationSetActiveSchema",
+			"definitions": {
+				"OrganizationSetActiveSchema": {
+					"type": "object",
+					"properties": {
+						"orgId": {
+							"type": "string",
+							"format": "uuid"
+						}
+					},
+					"required": ["orgId"],
+					"additionalProperties": false
+				}
+			}
+		},
+		"ProjectGetAllSchema": {
+			"$ref": "#/definitions/ProjectGetAllSchema",
+			"definitions": {
+				"ProjectGetAllSchema": {
+					"type": "object",
+					"properties": {},
+					"additionalProperties": false
+				}
+			}
+		},
+		"ProjectPropertyDefinitionsSchema": {
+			"$ref": "#/definitions/ProjectPropertyDefinitionsSchema",
+			"definitions": {
+				"ProjectPropertyDefinitionsSchema": {
+					"type": "object",
+					"properties": {},
+					"additionalProperties": false
+				}
+			}
+		},
+		"ProjectSetActiveSchema": {
+			"$ref": "#/definitions/ProjectSetActiveSchema",
+			"definitions": {
+				"ProjectSetActiveSchema": {
+					"type": "object",
+					"properties": {
+						"projectId": {
+							"type": "integer",
+							"exclusiveMinimum": 0
+						}
+					},
+					"required": ["projectId"],
+					"additionalProperties": false
+				}
+			}
+		}
+	}
 }

--- a/src/schema/tool-inputs.json
+++ b/src/schema/tool-inputs.json
@@ -1,0 +1,909 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "DashboardAddInsightSchema": {
+      "$ref": "#/definitions/DashboardAddInsightSchema",
+      "definitions": {
+        "DashboardAddInsightSchema": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "object",
+              "properties": {
+                "insight_id": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                "dashboard_id": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                }
+              },
+              "required": [
+                "insight_id",
+                "dashboard_id"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "data"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "DashboardCreateSchema": {
+      "$ref": "#/definitions/DashboardCreateSchema",
+      "definitions": {
+        "DashboardCreateSchema": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "description": {
+                  "type": "string"
+                },
+                "pinned": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "data"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "DashboardDeleteSchema": {
+      "$ref": "#/definitions/DashboardDeleteSchema",
+      "definitions": {
+        "DashboardDeleteSchema": {
+          "type": "object",
+          "properties": {
+            "dashboardId": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "dashboardId"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "DashboardGetAllSchema": {
+      "$ref": "#/definitions/DashboardGetAllSchema",
+      "definitions": {
+        "DashboardGetAllSchema": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "object",
+              "properties": {
+                "limit": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                },
+                "offset": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "search": {
+                  "type": "string"
+                },
+                "pinned": {
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "DashboardGetSchema": {
+      "$ref": "#/definitions/DashboardGetSchema",
+      "definitions": {
+        "DashboardGetSchema": {
+          "type": "object",
+          "properties": {
+            "dashboardId": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "dashboardId"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "DashboardUpdateSchema": {
+      "$ref": "#/definitions/DashboardUpdateSchema",
+      "definitions": {
+        "DashboardUpdateSchema": {
+          "type": "object",
+          "properties": {
+            "dashboardId": {
+              "type": "number"
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "pinned": {
+                  "type": "boolean"
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "dashboardId",
+            "data"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "DocumentationSearchSchema": {
+      "$ref": "#/definitions/DocumentationSearchSchema",
+      "definitions": {
+        "DocumentationSearchSchema": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "query"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "ErrorTrackingDetailsSchema": {
+      "$ref": "#/definitions/ErrorTrackingDetailsSchema",
+      "definitions": {
+        "ErrorTrackingDetailsSchema": {
+          "type": "object",
+          "properties": {
+            "issueId": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "dateFrom": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "dateTo": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          "required": [
+            "issueId"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "ErrorTrackingListSchema": {
+      "$ref": "#/definitions/ErrorTrackingListSchema",
+      "definitions": {
+        "ErrorTrackingListSchema": {
+          "type": "object",
+          "properties": {
+            "orderBy": {
+              "type": "string",
+              "enum": [
+                "occurrences",
+                "first_seen",
+                "last_seen",
+                "users",
+                "sessions"
+              ]
+            },
+            "dateFrom": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "dateTo": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "orderDirection": {
+              "type": "string",
+              "enum": [
+                "ASC",
+                "DESC"
+              ]
+            },
+            "filterTestAccounts": {
+              "type": "boolean"
+            },
+            "status": {
+              "type": "string",
+              "enum": [
+                "active",
+                "resolved",
+                "all",
+                "suppressed"
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "FeatureFlagCreateSchema": {
+      "$ref": "#/definitions/FeatureFlagCreateSchema",
+      "definitions": {
+        "FeatureFlagCreateSchema": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "key": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "filters": {
+              "type": "object",
+              "properties": {
+                "groups": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "properties": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "number"
+                                  }
+                                }
+                              ]
+                            },
+                            "operator": {
+                              "type": "string",
+                              "enum": [
+                                "exact",
+                                "is_not",
+                                "icontains",
+                                "not_icontains",
+                                "regex",
+                                "not_regex",
+                                "is_cleaned_path_exact",
+                                "exact",
+                                "is_not",
+                                "gt",
+                                "gte",
+                                "lt",
+                                "lte",
+                                "min",
+                                "max",
+                                "exact",
+                                "is_not",
+                                "in",
+                                "not_in"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "key",
+                            "value"
+                          ],
+                          "additionalProperties": false
+                        }
+                      },
+                      "rollout_percentage": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "properties",
+                      "rollout_percentage"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "required": [
+                "groups"
+              ],
+              "additionalProperties": false
+            },
+            "active": {
+              "type": "boolean"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "required": [
+            "name",
+            "key",
+            "description",
+            "filters",
+            "active"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "FeatureFlagDeleteSchema": {
+      "$ref": "#/definitions/FeatureFlagDeleteSchema",
+      "definitions": {
+        "FeatureFlagDeleteSchema": {
+          "type": "object",
+          "properties": {
+            "flagKey": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "flagKey"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "FeatureFlagGetAllSchema": {
+      "$ref": "#/definitions/FeatureFlagGetAllSchema",
+      "definitions": {
+        "FeatureFlagGetAllSchema": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": false
+        }
+      }
+    },
+    "FeatureFlagGetDefinitionSchema": {
+      "$ref": "#/definitions/FeatureFlagGetDefinitionSchema",
+      "definitions": {
+        "FeatureFlagGetDefinitionSchema": {
+          "type": "object",
+          "properties": {
+            "flagId": {
+              "type": "integer",
+              "exclusiveMinimum": 0
+            },
+            "flagKey": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "FeatureFlagUpdateSchema": {
+      "$ref": "#/definitions/FeatureFlagUpdateSchema",
+      "definitions": {
+        "FeatureFlagUpdateSchema": {
+          "type": "object",
+          "properties": {
+            "flagKey": {
+              "type": "string"
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "filters": {
+                  "type": "object",
+                  "properties": {
+                    "groups": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "properties": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "number"
+                                      }
+                                    }
+                                  ]
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "enum": [
+                                    "exact",
+                                    "is_not",
+                                    "icontains",
+                                    "not_icontains",
+                                    "regex",
+                                    "not_regex",
+                                    "is_cleaned_path_exact",
+                                    "exact",
+                                    "is_not",
+                                    "gt",
+                                    "gte",
+                                    "lt",
+                                    "lte",
+                                    "min",
+                                    "max",
+                                    "exact",
+                                    "is_not",
+                                    "in",
+                                    "not_in"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "value"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "rollout_percentage": {
+                            "type": "number"
+                          }
+                        },
+                        "required": [
+                          "properties",
+                          "rollout_percentage"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "groups"
+                  ],
+                  "additionalProperties": false
+                },
+                "active": {
+                  "type": "boolean"
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "flagKey",
+            "data"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "InsightCreateSchema": {
+      "$ref": "#/definitions/InsightCreateSchema",
+      "definitions": {
+        "InsightCreateSchema": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "query": {
+                  "type": "object",
+                  "properties": {
+                    "kind": {
+                      "type": "string",
+                      "const": "DataVisualizationNode"
+                    },
+                    "source": {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "const": "HogQLQuery"
+                        },
+                        "query": {
+                          "type": "string"
+                        },
+                        "explain": {
+                          "type": "boolean"
+                        },
+                        "filters": {
+                          "type": "object",
+                          "properties": {
+                            "dateRange": {
+                              "type": "object",
+                              "properties": {
+                                "date_from": {
+                                  "type": "string",
+                                  "description": "The start date of the date range. Could be a date string or a relative date string like '-7d'"
+                                },
+                                "date_to": {
+                                  "type": "string",
+                                  "description": "The end date of the date range. Could be a date string or a relative date string like '-1d'"
+                                }
+                              },
+                              "required": [
+                                "date_from",
+                                "date_to"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "query"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "source"
+                  ],
+                  "additionalProperties": false
+                },
+                "description": {
+                  "type": "string"
+                },
+                "saved": {
+                  "type": "boolean",
+                  "default": true
+                },
+                "favorited": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "name",
+                "query"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "data"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "InsightDeleteSchema": {
+      "$ref": "#/definitions/InsightDeleteSchema",
+      "definitions": {
+        "InsightDeleteSchema": {
+          "type": "object",
+          "properties": {
+            "insightId": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "insightId"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "InsightGetAllSchema": {
+      "$ref": "#/definitions/InsightGetAllSchema",
+      "definitions": {
+        "InsightGetAllSchema": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "object",
+              "properties": {
+                "limit": {
+                  "type": "number"
+                },
+                "offset": {
+                  "type": "number"
+                },
+                "saved": {
+                  "type": "boolean"
+                },
+                "favorited": {
+                  "type": "boolean"
+                },
+                "search": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "InsightGetSchema": {
+      "$ref": "#/definitions/InsightGetSchema",
+      "definitions": {
+        "InsightGetSchema": {
+          "type": "object",
+          "properties": {
+            "insightId": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "insightId"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "InsightGetSqlSchema": {
+      "$ref": "#/definitions/InsightGetSqlSchema",
+      "definitions": {
+        "InsightGetSqlSchema": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "maxLength": 1000,
+              "description": "Your natural language query describing the SQL insight (max 1000 characters)."
+            }
+          },
+          "required": [
+            "query"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "InsightUpdateSchema": {
+      "$ref": "#/definitions/InsightUpdateSchema",
+      "definitions": {
+        "InsightUpdateSchema": {
+          "type": "object",
+          "properties": {
+            "insightId": {
+              "type": "number"
+            },
+            "data": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "filters": {
+                  "type": "object",
+                  "additionalProperties": {}
+                },
+                "query": {
+                  "type": "object",
+                  "additionalProperties": {}
+                },
+                "saved": {
+                  "type": "boolean"
+                },
+                "favorited": {
+                  "type": "boolean"
+                },
+                "dashboard": {
+                  "type": "number"
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "insightId",
+            "data"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "LLMObservabilityGetCostsSchema": {
+      "$ref": "#/definitions/LLMObservabilityGetCostsSchema",
+      "definitions": {
+        "LLMObservabilityGetCostsSchema": {
+          "type": "object",
+          "properties": {
+            "projectId": {
+              "type": "integer",
+              "exclusiveMinimum": 0
+            },
+            "days": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "projectId"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "OrganizationGetAllSchema": {
+      "$ref": "#/definitions/OrganizationGetAllSchema",
+      "definitions": {
+        "OrganizationGetAllSchema": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": false
+        }
+      }
+    },
+    "OrganizationGetDetailsSchema": {
+      "$ref": "#/definitions/OrganizationGetDetailsSchema",
+      "definitions": {
+        "OrganizationGetDetailsSchema": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": false
+        }
+      }
+    },
+    "OrganizationSetActiveSchema": {
+      "$ref": "#/definitions/OrganizationSetActiveSchema",
+      "definitions": {
+        "OrganizationSetActiveSchema": {
+          "type": "object",
+          "properties": {
+            "orgId": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "required": [
+            "orgId"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "ProjectGetAllSchema": {
+      "$ref": "#/definitions/ProjectGetAllSchema",
+      "definitions": {
+        "ProjectGetAllSchema": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": false
+        }
+      }
+    },
+    "ProjectPropertyDefinitionsSchema": {
+      "$ref": "#/definitions/ProjectPropertyDefinitionsSchema",
+      "definitions": {
+        "ProjectPropertyDefinitionsSchema": {
+          "type": "object",
+          "properties": {},
+          "additionalProperties": false
+        }
+      }
+    },
+    "ProjectSetActiveSchema": {
+      "$ref": "#/definitions/ProjectSetActiveSchema",
+      "definitions": {
+        "ProjectSetActiveSchema": {
+          "type": "object",
+          "properties": {
+            "projectId": {
+              "type": "integer",
+              "exclusiveMinimum": 0
+            }
+          },
+          "required": [
+            "projectId"
+          ],
+          "additionalProperties": false
+        }
+      }
+    }
+  }
+}

--- a/src/schema/tool-inputs.ts
+++ b/src/schema/tool-inputs.ts
@@ -1,0 +1,117 @@
+import { z } from "zod";
+import { FilterGroupsSchema, UpdateFeatureFlagInputSchema } from "./flags";
+import { CreateInsightInputSchema, UpdateInsightInputSchema, ListInsightsSchema } from "./insights";
+import {
+	CreateDashboardInputSchema,
+	UpdateDashboardInputSchema,
+	ListDashboardsSchema,
+	AddInsightToDashboardSchema,
+} from "./dashboards";
+import { ErrorDetailsSchema, ListErrorsSchema } from "./errors";
+
+export const DashboardAddInsightSchema = z.object({
+	data: AddInsightToDashboardSchema,
+});
+
+export const DashboardCreateSchema = z.object({
+	data: CreateDashboardInputSchema,
+});
+
+export const DashboardDeleteSchema = z.object({
+	dashboardId: z.number(),
+});
+
+export const DashboardGetSchema = z.object({
+	dashboardId: z.number(),
+});
+
+export const DashboardGetAllSchema = z.object({
+	data: ListDashboardsSchema.optional(),
+});
+
+export const DashboardUpdateSchema = z.object({
+	dashboardId: z.number(),
+	data: UpdateDashboardInputSchema,
+});
+
+export const DocumentationSearchSchema = z.object({
+	query: z.string(),
+});
+
+export const ErrorTrackingDetailsSchema = ErrorDetailsSchema;
+
+export const ErrorTrackingListSchema = ListErrorsSchema;
+
+export const FeatureFlagCreateSchema = z.object({
+	name: z.string(),
+	key: z.string(),
+	description: z.string(),
+	filters: FilterGroupsSchema,
+	active: z.boolean(),
+	tags: z.array(z.string()).optional(),
+});
+
+export const FeatureFlagDeleteSchema = z.object({
+	flagKey: z.string(),
+});
+
+export const FeatureFlagGetAllSchema = z.object({});
+
+export const FeatureFlagGetDefinitionSchema = z.object({
+	flagId: z.number().int().positive().optional(),
+	flagKey: z.string().optional(),
+});
+
+export const FeatureFlagUpdateSchema = z.object({
+	flagKey: z.string(),
+	data: UpdateFeatureFlagInputSchema,
+});
+
+export const InsightCreateSchema = z.object({
+	data: CreateInsightInputSchema,
+});
+
+export const InsightDeleteSchema = z.object({
+	insightId: z.number(),
+});
+
+export const InsightGetSchema = z.object({
+	insightId: z.number(),
+});
+
+export const InsightGetAllSchema = z.object({
+	data: ListInsightsSchema.optional(),
+});
+
+export const InsightGetSqlSchema = z.object({
+	query: z
+		.string()
+		.max(1000)
+		.describe("Your natural language query describing the SQL insight (max 1000 characters)."),
+});
+
+export const InsightUpdateSchema = z.object({
+	insightId: z.number(),
+	data: UpdateInsightInputSchema,
+});
+
+export const LLMObservabilityGetCostsSchema = z.object({
+	projectId: z.number().int().positive(),
+	days: z.number().optional(),
+});
+
+export const OrganizationGetDetailsSchema = z.object({});
+
+export const OrganizationGetAllSchema = z.object({});
+
+export const OrganizationSetActiveSchema = z.object({
+	orgId: z.string().uuid(),
+});
+
+export const ProjectGetAllSchema = z.object({});
+
+export const ProjectPropertyDefinitionsSchema = z.object({});
+
+export const ProjectSetActiveSchema = z.object({
+	projectId: z.number().int().positive(),
+});

--- a/src/tools/dashboards/addInsight.ts
+++ b/src/tools/dashboards/addInsight.ts
@@ -1,11 +1,9 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
-import { AddInsightToDashboardSchema } from "../../schema/dashboards";
 import { getProjectBaseUrl } from "../../lib/utils/api";
+import { DashboardAddInsightSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	data: AddInsightToDashboardSchema,
-});
+const schema = DashboardAddInsightSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/dashboards/create.ts
+++ b/src/tools/dashboards/create.ts
@@ -1,11 +1,9 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
-import { CreateDashboardInputSchema } from "../../schema/dashboards";
 import { getProjectBaseUrl } from "../../lib/utils/api";
+import { DashboardCreateSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	data: CreateDashboardInputSchema,
-});
+const schema = DashboardCreateSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/dashboards/delete.ts
+++ b/src/tools/dashboards/delete.ts
@@ -1,9 +1,8 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
+import { DashboardDeleteSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	dashboardId: z.number(),
-});
+const schema = DashboardDeleteSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/dashboards/get.ts
+++ b/src/tools/dashboards/get.ts
@@ -1,9 +1,8 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
+import { DashboardGetSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	dashboardId: z.number(),
-});
+const schema = DashboardGetSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/dashboards/getAll.ts
+++ b/src/tools/dashboards/getAll.ts
@@ -1,10 +1,8 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
-import { ListDashboardsSchema } from "../../schema/dashboards";
+import { DashboardGetAllSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	data: ListDashboardsSchema.optional(),
-});
+const schema = DashboardGetAllSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/dashboards/update.ts
+++ b/src/tools/dashboards/update.ts
@@ -1,12 +1,9 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
-import { UpdateDashboardInputSchema } from "../../schema/dashboards";
 import { getProjectBaseUrl } from "../../lib/utils/api";
+import { DashboardUpdateSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	dashboardId: z.number(),
-	data: UpdateDashboardInputSchema,
-});
+const schema = DashboardUpdateSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/documentation/searchDocs.ts
+++ b/src/tools/documentation/searchDocs.ts
@@ -1,10 +1,9 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
 import { docsSearch } from "../../inkeepApi";
+import { DocumentationSearchSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	query: z.string(),
-});
+const schema = DocumentationSearchSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/errorTracking/errorDetails.ts
+++ b/src/tools/errorTracking/errorDetails.ts
@@ -1,8 +1,8 @@
 import type { z } from "zod";
 import type { Context, Tool } from "../types";
-import { ErrorDetailsSchema } from "../../schema/errors";
+import { ErrorTrackingDetailsSchema } from "../../schema/tool-inputs";
 
-const schema = ErrorDetailsSchema;
+const schema = ErrorTrackingDetailsSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/errorTracking/listErrors.ts
+++ b/src/tools/errorTracking/listErrors.ts
@@ -1,8 +1,8 @@
 import type { z } from "zod";
 import type { Context, Tool } from "../types";
-import { ListErrorsSchema } from "../../schema/errors";
+import { ErrorTrackingListSchema } from "../../schema/tool-inputs";
 
-const schema = ListErrorsSchema;
+const schema = ErrorTrackingListSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/featureFlags/create.ts
+++ b/src/tools/featureFlags/create.ts
@@ -1,16 +1,9 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
-import { FilterGroupsSchema } from "../../schema/flags";
 import { getProjectBaseUrl } from "../../lib/utils/api";
+import { FeatureFlagCreateSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	name: z.string(),
-	key: z.string(),
-	description: z.string(),
-	filters: FilterGroupsSchema,
-	active: z.boolean(),
-	tags: z.array(z.string()).optional(),
-});
+const schema = FeatureFlagCreateSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/featureFlags/delete.ts
+++ b/src/tools/featureFlags/delete.ts
@@ -1,9 +1,8 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
+import { FeatureFlagDeleteSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	flagKey: z.string(),
-});
+const schema = FeatureFlagDeleteSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/featureFlags/getAll.ts
+++ b/src/tools/featureFlags/getAll.ts
@@ -1,7 +1,8 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
+import { FeatureFlagGetAllSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({});
+const schema = FeatureFlagGetAllSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/featureFlags/getDefinition.ts
+++ b/src/tools/featureFlags/getDefinition.ts
@@ -1,10 +1,8 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
+import { FeatureFlagGetDefinitionSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	flagId: z.number().int().positive().optional(),
-	flagKey: z.string().optional(),
-});
+const schema = FeatureFlagGetDefinitionSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/featureFlags/update.ts
+++ b/src/tools/featureFlags/update.ts
@@ -1,12 +1,9 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
-import { UpdateFeatureFlagInputSchema } from "../../schema/flags";
 import { getProjectBaseUrl } from "../../lib/utils/api";
+import { FeatureFlagUpdateSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	flagKey: z.string(),
-	data: UpdateFeatureFlagInputSchema,
-});
+const schema = FeatureFlagUpdateSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/insights/create.ts
+++ b/src/tools/insights/create.ts
@@ -1,11 +1,9 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
-import { CreateInsightInputSchema } from "../../schema/insights";
 import { getProjectBaseUrl } from "../../lib/utils/api";
+import { InsightCreateSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	data: CreateInsightInputSchema,
-});
+const schema = InsightCreateSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/insights/delete.ts
+++ b/src/tools/insights/delete.ts
@@ -1,9 +1,8 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
+import { InsightDeleteSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	insightId: z.number(),
-});
+const schema = InsightDeleteSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/insights/get.ts
+++ b/src/tools/insights/get.ts
@@ -1,10 +1,9 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
 import { getProjectBaseUrl } from "../../lib/utils/api";
+import { InsightGetSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	insightId: z.number(),
-});
+const schema = InsightGetSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/insights/getAll.ts
+++ b/src/tools/insights/getAll.ts
@@ -1,11 +1,9 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
-import { ListInsightsSchema } from "../../schema/insights";
 import { getProjectBaseUrl } from "../../lib/utils/api";
+import { InsightGetAllSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	data: ListInsightsSchema.optional(),
-});
+const schema = InsightGetAllSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/insights/getSqlInsight.ts
+++ b/src/tools/insights/getSqlInsight.ts
@@ -1,12 +1,8 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
+import { InsightGetSqlSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	query: z
-		.string()
-		.max(1000)
-		.describe("Your natural language query describing the SQL insight (max 1000 characters)."),
-});
+const schema = InsightGetSqlSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/insights/update.ts
+++ b/src/tools/insights/update.ts
@@ -1,12 +1,9 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
-import { UpdateInsightInputSchema } from "../../schema/insights";
 import { getProjectBaseUrl } from "../../lib/utils/api";
+import { InsightUpdateSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	insightId: z.number(),
-	data: UpdateInsightInputSchema,
-});
+const schema = InsightUpdateSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/llmObservability/getLLMCosts.ts
+++ b/src/tools/llmObservability/getLLMCosts.ts
@@ -1,10 +1,8 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
+import { LLMObservabilityGetCostsSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	projectId: z.number().int().positive(),
-	days: z.number().optional(),
-});
+const schema = LLMObservabilityGetCostsSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/organizations/getDetails.ts
+++ b/src/tools/organizations/getDetails.ts
@@ -1,7 +1,8 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
+import { OrganizationGetDetailsSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({});
+const schema = OrganizationGetDetailsSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/organizations/getOrganizations.ts
+++ b/src/tools/organizations/getOrganizations.ts
@@ -1,7 +1,8 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
+import { OrganizationGetAllSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({});
+const schema = OrganizationGetAllSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/organizations/setActive.ts
+++ b/src/tools/organizations/setActive.ts
@@ -1,9 +1,8 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
+import { OrganizationSetActiveSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	orgId: z.string().uuid(),
-});
+const schema = OrganizationSetActiveSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/projects/getProjects.ts
+++ b/src/tools/projects/getProjects.ts
@@ -1,7 +1,8 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
+import { ProjectGetAllSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({});
+const schema = ProjectGetAllSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/projects/propertyDefinitions.ts
+++ b/src/tools/projects/propertyDefinitions.ts
@@ -1,7 +1,8 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
+import { ProjectPropertyDefinitionsSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({});
+const schema = ProjectPropertyDefinitionsSchema;
 
 type Params = z.infer<typeof schema>;
 

--- a/src/tools/projects/setActive.ts
+++ b/src/tools/projects/setActive.ts
@@ -1,9 +1,8 @@
-import { z } from "zod";
+import type { z } from "zod";
 import type { Context, Tool } from "../types";
+import { ProjectSetActiveSchema } from "../../schema/tool-inputs";
 
-const schema = z.object({
-	projectId: z.number().int().positive(),
-});
+const schema = ProjectSetActiveSchema;
 
 type Params = z.infer<typeof schema>;
 


### PR DESCRIPTION
Ideally, it'd be nice to share the same API for tool inputs in node and python, this pre-emptively pulls the tool definitions out into their own file and generates JSON schema for them, which we will use later to create Pydantic models for the python implementations.