### PR TITLE
feat: detect dev based on node env

### DIFF
--- a/typescript/src/lib/constants.ts
+++ b/typescript/src/lib/constants.ts
@@ -1,3 +1,3 @@
-export const DEV = false;
+export const DEV = process.env.NODE_ENV === 'development';
 
 export const BASE_URL = DEV ? "http://localhost:8010" : "https://us.posthog.com";


### PR DESCRIPTION
Make it so `DEV` is always enabled when running locally instead of manually toggling a flag
`export const DEV = process.env.NODE_ENV === 'development';`
