### PR TITLE
feat: detect dev based on node env

### DIFF
--- a/typescript/src/lib/constants.ts
+++ b/typescript/src/lib/constants.ts
@@ -1,3 +1,3 @@
-export const DEV = false;
+export const DEV = process.env.NODE_ENV === 'development';
 
 export const BASE_URL = DEV ? "http://localhost:8010" : "https://us.posthog.com";


### PR DESCRIPTION
Inside @typescript/src/api/client.ts we have the sqlInsight tool. In there we do a bunch of data manipulation which caused a valid response from Max AI to only return to the client:
```
  {"columns":["type","data"],"results":[{"type":"message","data":{"type":"ack"}}]}
```

So we were stripping out all the useful data from the Max tool, causing this to infinitely run.
I simplified the parsing, only removing `ack` messages.
We now end up with something like
```json
[{"type":"message","data":{"answer":{"kind":"HogQLQuery","query":"SELECT count(DISTINCT person_id) AS unique_users_last_30_days\nFROM events\nWHERE timestamp >= now() - INTERVAL 30 DAY\n  AND person_id IS NOT NULL"},"id":"c86a3a3d-24df-44d0-ac45-beb03ba89f63","plan":"Logic:\n- Filter the `events` table to include only events with `timestamp` in the last 30 days.\n- Exclude any events where `person_id` is null, to ensure only identified users are counted.\n- Count the number of distinct `person_id` values in this filtered set.\n\nSources:\n- events\n    - Used to filter by `timestamp >= now() - interval '30 days'` and `person_id IS NOT NULL`.\n    - Aggregation: `COUNT(DISTINCT person_id)`.","query":"Count unique users who triggered any event in the last 30 days","type":"ai/viz"}},{"type":"message","data":{"content":"You'll be given a JSON object with the results of a query.\n\nHere is the generated HogQL (a PostHog's subset of ClickHouse SQL) query used to retrieve the results:\n\n```\nSELECT count(DISTINCT person_id) AS unique_users_last_30_days\nFROM events\nWHERE timestamp >= now() - INTERVAL 30 DAY\n  AND person_id IS NOT NULL\n```\n\nYou'll be given a JSON object with the results of a query.\n\nHere is the results table of the HogQLQuery I created to answer your latest question:\n\n```\n[[1969]]\n```\n\nThe current date and time is 2025-07-24 13:37:04 UTC, which is 2025-07-24 13:37:04 in this project's timezone (UTC).\nIt's expected that the data point for the current period can have a drop in value, as data collection is still ongoing for it. Do not point this out.","id":"3e87a36f-54dd-44bb-83cc-abec16cb640b","tool_call_id":"98339175-2ce6-47cb-b6e5-dfc511286dd2","type":"tool"}}]
``` 

Which makes this tool functional again 🥳 