### PR TITLE
chore: use the same tool descriptions across python / ts definitions

### DIFF
--- a/python/api/client.py
+++ b/python/api/client.py
@@ -362,7 +362,7 @@ class InsightResource:
 
         return result
 
-    async def sql_insight(self, query: str) -> Result[dict]:
+    async def sql_insight(self, query: str) -> Result[str]:
         result = await self.client._fetch_with_schema(
             f"{self.client.base_url}/api/environments/{self.project_id}/max_tools/create_and_query_insight/",
             SqlInsightResponse,
@@ -374,51 +374,7 @@ class InsightResource:
         if is_success(result):
             try:
                 response_data = result.data.root
-                if response_data and len(response_data) > 0:
-                    generated_query = None
-                    execution_plan = None
-                    query_results = None
-
-                    for item in response_data:
-                        if item.data:
-                            data = item.data
-                            item_type = data.get("type", "")
-
-                            if item_type == "ai/viz":
-                                if "answer" in data:
-                                    answer = data["answer"]
-                                    generated_query = str(answer) if answer else None
-
-                                if "plan" in data:
-                                    execution_plan = data["plan"]
-
-                            elif item_type == "tool":
-                                if "content" in data:
-                                    query_results = data["content"]
-
-                            elif "columns" in data and "results" in data:
-                                columns = data.get("columns", [])
-                                results = data.get("results", [])
-                                if columns or results:
-                                    query_results = f"Columns: {columns}\nResults: {results}"
-
-                    response_text = []
-
-                    if generated_query:
-                        response_text.append(f"Generated Query:\n{generated_query}")
-
-                    if execution_plan:
-                        response_text.append(f"Execution Plan:\n{execution_plan}")
-
-                    if query_results:
-                        response_text.append(f"Query Results:\n{query_results}")
-
-                    if not response_text:
-                        response_text.append("Query executed but no detailed results were returned.")
-
-                    return SuccessResult({"response": "\n\n".join(response_text)})
-
-                return SuccessResult({"response": "No data returned from SQL insight API."})
+                return SuccessResult(json.dumps(response_data))
             except Exception as e:
                 return ErrorResult(Exception(f"Error parsing SQL insight response: {str(e)}"))
 

--- a/python/tools/dashboards/add_insight.py
+++ b/python/tools/dashboards/add_insight.py
@@ -4,6 +4,7 @@ from api.client import is_error, is_success
 from lib.utils.api import get_project_base_url
 from schema.dashboards import AddInsightToDashboard
 from schema.tool_inputs import DashboardAddInsightSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -36,13 +37,11 @@ async def add_insight_to_dashboard_handler(context: Context, params: DashboardAd
 
 
 def add_insight_to_dashboard_tool() -> Tool[DashboardAddInsightSchema]:
+    definition = get_tool_definition("add-insight-to-dashboard")
+
     return Tool(
         name="add-insight-to-dashboard",
-        description="""
-        - Add an existing insight to a dashboard.
-        - Requires insight ID and dashboard ID.
-        - Optionally supports layout and color customization.
-        """,
+        description=definition["description"],
         schema=DashboardAddInsightSchema,
         handler=add_insight_to_dashboard_handler,
     )

--- a/python/tools/dashboards/create.py
+++ b/python/tools/dashboards/create.py
@@ -3,6 +3,7 @@ import json
 from api.client import is_error, is_success
 from lib.utils.api import get_project_base_url
 from schema.tool_inputs import DashboardCreateSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -26,12 +27,11 @@ async def create_dashboard_handler(context: Context, params: DashboardCreateSche
 
 
 def create_dashboard_tool() -> Tool[DashboardCreateSchema]:
+    definition = get_tool_definition("dashboard-create")
+
     return Tool(
         name="dashboard-create",
-        description="""
-        - Create a new dashboard in the project.
-        - Requires name and optional description, tags, and other properties.
-        """,
+        description=definition["description"],
         schema=DashboardCreateSchema,
         handler=create_dashboard_handler,
     )

--- a/python/tools/dashboards/delete.py
+++ b/python/tools/dashboards/delete.py
@@ -2,6 +2,7 @@ import json
 
 from api.client import is_error, is_success
 from schema.tool_inputs import DashboardDeleteSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -17,9 +18,11 @@ async def delete_dashboard_handler(context: Context, params: DashboardDeleteSche
 
 
 def delete_dashboard_tool() -> Tool[DashboardDeleteSchema]:
+    definition = get_tool_definition("dashboard-delete")
+
     return Tool(
         name="dashboard-delete",
-        description="Delete a dashboard by ID (soft delete - marks as deleted).",
+        description=definition["description"],
         schema=DashboardDeleteSchema,
         handler=delete_dashboard_handler,
     )

--- a/python/tools/dashboards/get.py
+++ b/python/tools/dashboards/get.py
@@ -2,6 +2,7 @@ import json
 
 from api.client import is_error, is_success
 from schema.tool_inputs import DashboardGetSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -17,9 +18,11 @@ async def get_dashboard_handler(context: Context, params: DashboardGetSchema) ->
 
 
 def get_dashboard_tool() -> Tool[DashboardGetSchema]:
+    definition = get_tool_definition("dashboard-get")
+
     return Tool(
         name="dashboard-get",
-        description="Get a specific dashboard by ID.",
+        description=definition["description"],
         schema=DashboardGetSchema,
         handler=get_dashboard_handler,
     )

--- a/python/tools/dashboards/get_all.py
+++ b/python/tools/dashboards/get_all.py
@@ -2,6 +2,7 @@ import json
 
 from api.client import is_error, is_success
 from schema.tool_inputs import DashboardGetAllSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -20,12 +21,11 @@ async def get_all_dashboards_handler(context: Context, params: DashboardGetAllSc
 
 
 def get_all_dashboards_tool() -> Tool[DashboardGetAllSchema]:
+    definition = get_tool_definition("dashboards-get-all")
+
     return Tool(
         name="dashboards-get-all",
-        description="""
-        - Get all dashboards in the project with optional filtering.
-        - Can filter by pinned status, search term, or pagination.
-        """,
+        description=definition["description"],
         schema=DashboardGetAllSchema,
         handler=get_all_dashboards_handler,
     )

--- a/python/tools/dashboards/update.py
+++ b/python/tools/dashboards/update.py
@@ -3,6 +3,7 @@ import json
 from api.client import is_error, is_success
 from lib.utils.api import get_project_base_url
 from schema.tool_inputs import DashboardUpdateSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -26,12 +27,11 @@ async def update_dashboard_handler(context: Context, params: DashboardUpdateSche
 
 
 def update_dashboard_tool() -> Tool[DashboardUpdateSchema]:
+    definition = get_tool_definition("dashboard-update")
+
     return Tool(
         name="dashboard-update",
-        description="""
-        - Update an existing dashboard by ID.
-        - Can update name, description, pinned status or tags.
-        """,
+        description=definition["description"],
         schema=DashboardUpdateSchema,
         handler=update_dashboard_handler,
     )

--- a/python/tools/documentation/search_docs.py
+++ b/python/tools/documentation/search_docs.py
@@ -3,6 +3,7 @@ import json
 import httpx
 
 from schema.tool_inputs import DocumentationSearchSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -45,12 +46,11 @@ async def search_docs_handler(context: Context, params: DocumentationSearchSchem
 
 
 def search_docs_tool() -> Tool[DocumentationSearchSchema]:
+    definition = get_tool_definition("docs-search")
+
     return Tool(
         name="docs-search",
-        description="""
-        - Use this tool to search the PostHog documentation for information that can help the user with their request.
-        - Use it as a fallback when you cannot answer the user's request using other tools in this MCP.
-        """,
+        description=definition["description"],
         schema=DocumentationSearchSchema,
         handler=search_docs_handler,
     )

--- a/python/tools/error_tracking/error_details.py
+++ b/python/tools/error_tracking/error_details.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 
 from api.client import is_error, is_success
 from schema.tool_inputs import ErrorTrackingDetailsSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -28,9 +29,11 @@ async def error_details_handler(context: Context, params: ErrorTrackingDetailsSc
 
 
 def error_details_tool() -> Tool[ErrorTrackingDetailsSchema]:
+    definition = get_tool_definition("error-details")
+
     return Tool(
         name="error-details",
-        description="Use this tool to get the details of an error in the project.",
+        description=definition["description"],
         schema=ErrorTrackingDetailsSchema,
         handler=error_details_handler,
     )

--- a/python/tools/error_tracking/list_errors.py
+++ b/python/tools/error_tracking/list_errors.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 
 from api.client import is_error, is_success
 from schema.tool_inputs import ErrorTrackingListSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -37,9 +38,11 @@ async def list_errors_handler(context: Context, params: ErrorTrackingListSchema)
 
 
 def list_errors_tool() -> Tool[ErrorTrackingListSchema]:
+    definition = get_tool_definition("list-errors")
+
     return Tool(
         name="list-errors",
-        description="Use this tool to list errors in the project.",
+        description=definition["description"],
         schema=ErrorTrackingListSchema,
         handler=list_errors_handler,
     )

--- a/python/tools/feature_flags/create.py
+++ b/python/tools/feature_flags/create.py
@@ -3,6 +3,7 @@ import json
 from api.client import is_error, is_success
 from lib.utils.api import get_project_base_url
 from schema.tool_inputs import FeatureFlagCreateSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -27,13 +28,11 @@ async def create_feature_flag_handler(context: Context, params: FeatureFlagCreat
 
 
 def create_feature_flag_tool() -> Tool[FeatureFlagCreateSchema]:
+    definition = get_tool_definition("create-feature-flag")
+
     return Tool(
         name="create-feature-flag",
-        description="""Creates a new feature flag in the project. Once you have created a feature flag, you should:
-     - Ask the user if they want to add it to their codebase
-     - Use the "search-docs" tool to find documentation on how to add feature flags to the codebase (search for the right language / framework)
-     - Clarify where it should be added and then add it.
-        """,
+        description=definition["description"],
         schema=FeatureFlagCreateSchema,
         handler=create_feature_flag_handler,
     )

--- a/python/tools/feature_flags/delete.py
+++ b/python/tools/feature_flags/delete.py
@@ -2,6 +2,7 @@ import json
 
 from api.client import is_error, is_success
 from schema.tool_inputs import FeatureFlagDeleteSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -34,9 +35,11 @@ async def delete_feature_flag_handler(context: Context, params: FeatureFlagDelet
 
 
 def delete_feature_flag_tool() -> Tool[FeatureFlagDeleteSchema]:
+    definition = get_tool_definition("delete-feature-flag")
+
     return Tool(
         name="delete-feature-flag",
-        description="Deletes a feature flag from the project.",
+        description=definition["description"],
         schema=FeatureFlagDeleteSchema,
         handler=delete_feature_flag_handler,
     )

--- a/python/tools/feature_flags/get_all.py
+++ b/python/tools/feature_flags/get_all.py
@@ -2,6 +2,7 @@ import json
 
 from api.client import is_error, is_success
 from schema.tool_inputs import FeatureFlagGetAllSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -21,9 +22,11 @@ async def get_all_feature_flags_handler(context: Context, _params: FeatureFlagGe
 
 
 def get_all_feature_flags_tool() -> Tool[FeatureFlagGetAllSchema]:
+    definition = get_tool_definition("feature-flag-get-all")
+
     return Tool(
-        name="feature-flags-get-all",
-        description="Use this tool to get all feature flags for the project.",
+        name="feature-flag-get-all",
+        description=definition["description"],
         schema=FeatureFlagGetAllSchema,
         handler=get_all_feature_flags_handler,
     )

--- a/python/tools/feature_flags/get_definition.py
+++ b/python/tools/feature_flags/get_definition.py
@@ -2,6 +2,7 @@ import json
 
 from api.client import is_error, is_success
 from schema.tool_inputs import FeatureFlagGetDefinitionSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -41,13 +42,11 @@ async def get_feature_flag_definition_handler(context: Context, params: FeatureF
 
 
 def get_feature_flag_definition_tool() -> Tool[FeatureFlagGetDefinitionSchema]:
+    definition = get_tool_definition("feature-flag-get-definition")
+
     return Tool(
         name="feature-flag-get-definition",
-        description="""
-        - Use this tool to get the definition of a feature flag.
-        - You can provide either the flagId or the flagKey.
-        - If you provide both, the flagId will be used.
-        """,
+        description=definition["description"],
         schema=FeatureFlagGetDefinitionSchema,
         handler=get_feature_flag_definition_handler,
     )

--- a/python/tools/feature_flags/update.py
+++ b/python/tools/feature_flags/update.py
@@ -3,6 +3,7 @@ import json
 from api.client import is_error, is_success
 from lib.utils.api import get_project_base_url
 from schema.tool_inputs import FeatureFlagUpdateSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -30,9 +31,11 @@ async def update_feature_flag_handler(context: Context, params: FeatureFlagUpdat
 
 
 def update_feature_flag_tool() -> Tool[FeatureFlagUpdateSchema]:
+    definition = get_tool_definition("update-feature-flag")
+
     return Tool(
         name="update-feature-flag",
-        description="Updates an existing feature flag in the project.",
+        description=definition["description"],
         schema=FeatureFlagUpdateSchema,
         handler=update_feature_flag_handler,
     )

--- a/python/tools/insights/create.py
+++ b/python/tools/insights/create.py
@@ -3,6 +3,7 @@ import json
 from api.client import is_error, is_success
 from lib.utils.api import get_project_base_url
 from schema.tool_inputs import InsightCreateSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -27,9 +28,11 @@ async def create_insight_handler(context: Context, params: InsightCreateSchema) 
 
 
 def create_insight_tool() -> Tool[InsightCreateSchema]:
+    definition = get_tool_definition("insight-create-from-query")
+
     return Tool(
-        name="create-insight",
-        description="Creates a new insight in the project.",
+        name="insight-create-from-query",
+        description=definition["description"],
         schema=InsightCreateSchema,
         handler=create_insight_handler,
     )

--- a/python/tools/insights/delete.py
+++ b/python/tools/insights/delete.py
@@ -2,6 +2,7 @@ import json
 
 from api.client import is_error, is_success
 from schema.tool_inputs import InsightDeleteSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -17,9 +18,11 @@ async def delete_insight_handler(context: Context, params: InsightDeleteSchema) 
 
 
 def delete_insight_tool() -> Tool[InsightDeleteSchema]:
+    definition = get_tool_definition("insight-delete")
+
     return Tool(
         name="insight-delete",
-        description="Delete an insight by ID (soft delete - marks as deleted).",
+        description=definition["description"],
         schema=InsightDeleteSchema,
         handler=delete_insight_handler,
     )

--- a/python/tools/insights/get.py
+++ b/python/tools/insights/get.py
@@ -3,6 +3,7 @@ import json
 from api.client import is_error, is_success
 from lib.utils.api import get_project_base_url
 from schema.tool_inputs import InsightGetSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -26,9 +27,11 @@ async def get_insight_handler(context: Context, params: InsightGetSchema) -> Too
 
 
 def get_insight_tool() -> Tool[InsightGetSchema]:
+    definition = get_tool_definition("insight-get")
+
     return Tool(
         name="insight-get",
-        description="Get a specific insight by ID.",
+        description=definition["description"],
         schema=InsightGetSchema,
         handler=get_insight_handler,
     )

--- a/python/tools/insights/get_all.py
+++ b/python/tools/insights/get_all.py
@@ -4,6 +4,7 @@ from api.client import is_error, is_success
 from lib.utils.api import get_project_base_url
 from schema.insights import ListInsights
 from schema.tool_inputs import InsightGetAllSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -40,9 +41,11 @@ async def get_all_insights_handler(context: Context, params: InsightGetAllSchema
 
 
 def get_all_insights_tool() -> Tool[InsightGetAllSchema]:
+    definition = get_tool_definition("insights-get-all")
+
     return Tool(
         name="insights-get-all",
-        description="Use this tool to get all insights for the project. Supports filtering by saved, favorited, and search query.",
+        description=definition["description"],
         schema=InsightGetAllSchema,
         handler=get_all_insights_handler,
     )

--- a/python/tools/insights/get_sql_insight.py
+++ b/python/tools/insights/get_sql_insight.py
@@ -1,5 +1,6 @@
 from api.client import is_error, is_success
 from schema.tool_inputs import InsightGetSqlSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -18,13 +19,15 @@ async def get_sql_insight_handler(context: Context, params: InsightGetSqlSchema)
 
     assert is_success(insight_result)
 
-    return ToolResult(content=insight_result.data["response"])
+    return ToolResult(content=insight_result.data)
 
 
 def get_sql_insight_tool() -> Tool[InsightGetSqlSchema]:
+    definition = get_tool_definition("get-sql-insight")
+
     return Tool(
         name="get-sql-insight",
-        description="Executes a SQL query and returns the results as an insight.",
+        description=definition["description"],
         schema=InsightGetSqlSchema,
         handler=get_sql_insight_handler,
     )

--- a/python/tools/insights/update.py
+++ b/python/tools/insights/update.py
@@ -3,6 +3,7 @@ import json
 from api.client import is_error, is_success
 from lib.utils.api import get_project_base_url
 from schema.tool_inputs import InsightUpdateSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -26,12 +27,11 @@ async def update_insight_handler(context: Context, params: InsightUpdateSchema) 
 
 
 def update_insight_tool() -> Tool[InsightUpdateSchema]:
+    definition = get_tool_definition("insight-update")
+
     return Tool(
         name="insight-update",
-        description="""
-        - Update an existing insight by ID.
-        - Can update name, description, filters, and other properties.
-        """,
+        description=definition["description"],
         schema=InsightUpdateSchema,
         handler=update_insight_handler,
     )

--- a/python/tools/llm_observability/get_llm_costs.py
+++ b/python/tools/llm_observability/get_llm_costs.py
@@ -2,6 +2,7 @@ import json
 
 from api.client import is_error, is_success
 from schema.tool_inputs import LLMObservabilityGetCostsSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -34,22 +35,11 @@ async def get_llm_costs_handler(context: Context, params: LLMObservabilityGetCos
 
 
 def get_llm_costs_tool() -> Tool[LLMObservabilityGetCostsSchema]:
+    definition = get_tool_definition("get-llm-total-costs-for-project")
+
     return Tool(
         name="get-llm-total-costs-for-project",
-        description="""
-        - Fetches the total LLM daily costs for each model for a project over a given number of days.
-        - If no number of days is provided, it defaults to 7.
-        - The results are sorted by model name.
-        - The total cost is rounded to 4 decimal places.
-        - The query is executed against the project's data warehouse.
-        - Show the results as a Markdown formatted table with the following information for each model:
-            - Model name
-            - Total cost in USD
-            - Each day's date
-            - Each day's cost in USD
-        - Write in bold the model name with the highest total cost.
-        - Properly render the markdown table in the response.
-        """,
+        description=definition["description"],
         schema=LLMObservabilityGetCostsSchema,
         handler=get_llm_costs_handler,
     )

--- a/python/tools/organizations/get_details.py
+++ b/python/tools/organizations/get_details.py
@@ -2,6 +2,7 @@ import json
 
 from api.client import is_error, is_success
 from schema.tool_inputs import OrganizationGetDetailsSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -18,9 +19,11 @@ async def get_organization_details_handler(context: Context, _params: Organizati
 
 
 def get_organization_details_tool() -> Tool[OrganizationGetDetailsSchema]:
+    definition = get_tool_definition("organization-details-get")
+
     return Tool(
         name="organization-details-get",
-        description="Use this tool to get the details of the active organization.",
+        description=definition["description"],
         schema=OrganizationGetDetailsSchema,
         handler=get_organization_details_handler,
     )

--- a/python/tools/organizations/get_organizations.py
+++ b/python/tools/organizations/get_organizations.py
@@ -2,6 +2,7 @@ import json
 
 from api.client import is_error, is_success
 from schema.tool_inputs import OrganizationGetAllSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -17,9 +18,11 @@ async def get_organizations_handler(context: Context, _params: OrganizationGetAl
 
 
 def get_organizations_tool() -> Tool[OrganizationGetAllSchema]:
+    definition = get_tool_definition("organizations-get")
+
     return Tool(
         name="organizations-get",
-        description="Use this tool to get the organizations the user has access to.",
+        description=definition["description"],
         schema=OrganizationGetAllSchema,
         handler=get_organizations_handler,
     )

--- a/python/tools/organizations/set_active.py
+++ b/python/tools/organizations/set_active.py
@@ -1,4 +1,5 @@
 from schema.tool_inputs import OrganizationSetActiveSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -11,9 +12,11 @@ async def set_active_handler(context: Context, params: OrganizationSetActiveSche
 
 
 def set_active_org_tool() -> Tool[OrganizationSetActiveSchema]:
+    definition = get_tool_definition("organization-set-active")
+
     return Tool(
         name="organization-set-active",
-        description="Use this tool to set the active organization.",
+        description=definition["description"],
         schema=OrganizationSetActiveSchema,
         handler=set_active_handler,
     )

--- a/python/tools/projects/get_projects.py
+++ b/python/tools/projects/get_projects.py
@@ -2,6 +2,7 @@ import json
 
 from api.client import is_error, is_success
 from schema.tool_inputs import ProjectGetAllSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -20,12 +21,11 @@ async def get_projects_handler(context: Context, _params: ProjectGetAllSchema) -
 
 
 def get_projects_tool() -> Tool[ProjectGetAllSchema]:
+    definition = get_tool_definition("projects-get")
+
     return Tool(
         name="projects-get",
-        description="""
-        - Fetches projects that the user has access to - the orgId is optional.
-        - Use this tool before you use any other tools (besides organization-* and docs-search) to allow user to select the project they want to use for subsequent requests.
-        """,
+        description=definition["description"],
         schema=ProjectGetAllSchema,
         handler=get_projects_handler,
     )

--- a/python/tools/projects/property_definitions.py
+++ b/python/tools/projects/property_definitions.py
@@ -2,6 +2,7 @@ import json
 
 from api.client import is_error, is_success
 from schema.tool_inputs import ProjectPropertyDefinitionsSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -20,9 +21,11 @@ async def property_definitions_handler(context: Context, _params: ProjectPropert
 
 
 def property_definitions_tool() -> Tool[ProjectPropertyDefinitionsSchema]:
+    definition = get_tool_definition("property-definitions")
+
     return Tool(
         name="property-definitions",
-        description="Use this tool to get the property definitions of the active project.",
+        description=definition["description"],
         schema=ProjectPropertyDefinitionsSchema,
         handler=property_definitions_handler,
     )

--- a/python/tools/projects/set_active.py
+++ b/python/tools/projects/set_active.py
@@ -1,4 +1,5 @@
 from schema.tool_inputs import ProjectSetActiveSchema
+from tools.tool_definitions import get_tool_definition
 from tools.types import Context, Tool, ToolResult
 
 
@@ -11,9 +12,11 @@ async def set_active_project_handler(context: Context, params: ProjectSetActiveS
 
 
 def set_active_project_tool() -> Tool[ProjectSetActiveSchema]:
+    definition = get_tool_definition("project-set-active")
+
     return Tool(
         name="project-set-active",
-        description="Use this tool to set the active project.",
+        description=definition["description"],
         schema=ProjectSetActiveSchema,
         handler=set_active_project_handler,
     )

--- a/python/tools/tool_definitions.py
+++ b/python/tools/tool_definitions.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+from typing import TypedDict
+
+
+class ToolDefinition(TypedDict):
+    description: str
+
+
+ToolDefinitions = dict[str, ToolDefinition]
+
+
+root_dir = Path(__file__).parent.parent.parent
+definitions_path = root_dir / "schema" / "tool-definitions.json"
+
+with open(definitions_path) as f:
+    tool_definitions: ToolDefinitions = json.load(f)
+
+
+def get_tool_definition(tool_name: str) -> ToolDefinition:
+    """Get a tool definition by name."""
+    definition = tool_definitions.get(tool_name)
+    if not definition:
+        raise ValueError(f"Tool definition not found for: {tool_name}")
+    return definition

--- a/schema/tool-definitions.json
+++ b/schema/tool-definitions.json
@@ -1,0 +1,83 @@
+{
+	"add-insight-to-dashboard": {
+		"description": "Add an existing insight to a dashboard. Requires insight ID and dashboard ID. Optionally supports layout and color customization."
+	},
+	"dashboard-create": {
+		"description": "Create a new dashboard in the project. Requires name and optional description, tags, and other properties."
+	},
+	"dashboard-delete": {
+		"description": "Delete a dashboard by ID (soft delete - marks as deleted)."
+	},
+	"dashboard-get": {
+		"description": "Get a specific dashboard by ID."
+	},
+	"dashboards-get-all": {
+		"description": "Get all dashboards in the project with optional filtering. Can filter by pinned status, search term, or pagination."
+	},
+	"dashboard-update": {
+		"description": "Update an existing dashboard by ID. Can update name, description, pinned status or tags."
+	},
+	"docs-search": {
+		"description": "Use this tool to search the PostHog documentation for information that can help the user with their request. Use it as a fallback when you cannot answer the user's request using other tools in this MCP."
+	},
+	"error-details": {
+		"description": "Use this tool to get the details of an error in the project."
+	},
+	"list-errors": {
+		"description": "Use this tool to list errors in the project."
+	},
+	"create-feature-flag": {
+		"description": "Creates a new feature flag in the project. Once you have created a feature flag, you should: Ask the user if they want to add it to their codebase, Use the \"search-docs\" tool to find documentation on how to add feature flags to the codebase (search for the right language / framework), Clarify where it should be added and then add it."
+	},
+	"delete-feature-flag": {
+		"description": "Use this tool to delete a feature flag in the project."
+	},
+	"feature-flag-get-all": {
+		"description": "Use this tool to get all feature flags in the project."
+	},
+	"feature-flag-get-definition": {
+		"description": "Use this tool to get the definition of a feature flag. You can provide either the flagId or the flagKey. If you provide both, the flagId will be used."
+	},
+	"update-feature-flag": {
+		"description": "Update a new feature flag in the project. To enable a feature flag, you should make sure it is active and the rollout percentage is set to 100 for the group you want to target. To disable a feature flag, you should make sure it is inactive, you can keep the rollout percentage as it is."
+	},
+	"insight-create-from-query": {
+		"description": "You can use this to save a query as an insight. You should only do this with a valid query that you have seen, or one you have modified slightly. If the user wants to see data, you should use the \"get-sql-insight\" tool to get that data instead. An insight requires a name, query, and other optional properties. The query should use HogQL, which is a variant of Clickhouse SQL."
+	},
+	"insight-delete": {
+		"description": "Delete an insight by ID (soft delete - marks as deleted)."
+	},
+	"insight-get": {
+		"description": "Get a specific insight by ID."
+	},
+	"insights-get-all": {
+		"description": "Get all insights in the project with optional filtering. Can filter by saved status, favorited status, or search term."
+	},
+	"get-sql-insight": {
+		"description": "Queries project's PostHog data warehouse based on a provided natural language question - don't provide SQL query as input but describe the output you want. Data warehouse schema includes data like events and persons. Use this tool to get a quick answer to a question about the data in the project, which can't be answered using other, more dedicated tools.Fetches the result as a Server-Sent Events (SSE) stream and provides the concatenated data content. When giving the results back to the user, first show the SQL query that was used, then briefly explain the query, then provide results in reasily readable format. You should also offer to save the query as an insight if the user wants to."
+	},
+	"insight-update": {
+		"description": "Update an existing insight by ID. Can update name, description, filters, and other properties."
+	},
+	"get-llm-total-costs-for-project": {
+		"description": "Fetches the total LLM daily costs for each model for a project over a given number of days. If no number of days is provided, it defaults to 7. The results are sorted by model name. The total cost is rounded to 4 decimal places. The query is executed against the project's data warehouse. Show the results as a Markdown formatted table with the following information for each model: Model name, Total cost in USD, Each day's date, Each day's cost in USD. Write in bold the model name with the highest total cost. Properly render the markdown table in the response."
+	},
+	"organization-details-get": {
+		"description": "Use this tool to get the details of the active organization."
+	},
+	"organizations-get": {
+		"description": "Use this tool to get the organizations the user has access to."
+	},
+	"organization-set-active": {
+		"description": "Use this tool to set the active organization."
+	},
+	"projects-get": {
+		"description": "Fetches projects that the user has access to - the orgId is optional. Use this tool before you use any other tools (besides organization-* and docs-search) to allow user to select the project they want to use for subsequent requests."
+	},
+	"property-definitions": {
+		"description": "Use this tool to get the property definitions of the active project."
+	},
+	"project-set-active": {
+		"description": "Use this tool to set the active project."
+	}
+}

--- a/typescript/src/schema/tool-inputs.ts
+++ b/typescript/src/schema/tool-inputs.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
-import { FilterGroupsSchema, UpdateFeatureFlagInputSchema } from "./flags";
-import { CreateInsightInputSchema, UpdateInsightInputSchema, ListInsightsSchema } from "./insights";
 import {
-	CreateDashboardInputSchema,
-	UpdateDashboardInputSchema,
-	ListDashboardsSchema,
 	AddInsightToDashboardSchema,
+	CreateDashboardInputSchema,
+	ListDashboardsSchema,
+	UpdateDashboardInputSchema,
 } from "./dashboards";
 import { ErrorDetailsSchema, ListErrorsSchema } from "./errors";
+import { FilterGroupsSchema, UpdateFeatureFlagInputSchema } from "./flags";
+import { CreateInsightInputSchema, ListInsightsSchema, UpdateInsightInputSchema } from "./insights";
 
 export const DashboardAddInsightSchema = z.object({
 	data: AddInsightToDashboardSchema,

--- a/typescript/src/tools/dashboards/addInsight.ts
+++ b/typescript/src/tools/dashboards/addInsight.ts
@@ -1,7 +1,8 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { getProjectBaseUrl } from "@/lib/utils/api";
 import { DashboardAddInsightSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = DashboardAddInsightSchema;
 
@@ -34,13 +35,11 @@ export const addInsightHandler = async (context: Context, params: Params) => {
 	return { content: [{ type: "text", text: JSON.stringify(resultWithUrls) }] };
 };
 
+const definition = getToolDefinition("add-insight-to-dashboard");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "add-insight-to-dashboard",
-	description: `
-        - Add an existing insight to a dashboard.
-        - Requires insight ID and dashboard ID.
-        - Optionally supports layout and color customization.
-    `,
+	description: definition.description,
 	schema,
 	handler: addInsightHandler,
 });

--- a/typescript/src/tools/dashboards/create.ts
+++ b/typescript/src/tools/dashboards/create.ts
@@ -1,7 +1,8 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { getProjectBaseUrl } from "@/lib/utils/api";
 import { DashboardCreateSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = DashboardCreateSchema;
 
@@ -24,12 +25,11 @@ export const createHandler = async (context: Context, params: Params) => {
 	return { content: [{ type: "text", text: JSON.stringify(dashboardWithUrl) }] };
 };
 
+const definition = getToolDefinition("dashboard-create");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "dashboard-create",
-	description: `
-        - Create a new dashboard in the project.
-        - Requires name and optional description, tags, and other properties.
-    `,
+	description: definition.description,
 	schema,
 	handler: createHandler,
 });

--- a/typescript/src/tools/dashboards/delete.ts
+++ b/typescript/src/tools/dashboards/delete.ts
@@ -1,6 +1,7 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { DashboardDeleteSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = DashboardDeleteSchema;
 
@@ -18,11 +19,11 @@ export const deleteHandler = async (context: Context, params: Params) => {
 	return { content: [{ type: "text", text: JSON.stringify(result.data) }] };
 };
 
+const definition = getToolDefinition("dashboard-delete");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "dashboard-delete",
-	description: `
-        - Delete a dashboard by ID (soft delete - marks as deleted).
-    `,
+	description: definition.description,
 	schema,
 	handler: deleteHandler,
 });

--- a/typescript/src/tools/dashboards/get.ts
+++ b/typescript/src/tools/dashboards/get.ts
@@ -1,6 +1,7 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { DashboardGetSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = DashboardGetSchema;
 
@@ -18,11 +19,11 @@ export const getHandler = async (context: Context, params: Params) => {
 	return { content: [{ type: "text", text: JSON.stringify(dashboardResult.data) }] };
 };
 
+const definition = getToolDefinition("dashboard-get");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "dashboard-get",
-	description: `
-        - Get a specific dashboard by ID.
-    `,
+	description: definition.description,
 	schema,
 	handler: getHandler,
 });

--- a/typescript/src/tools/dashboards/getAll.ts
+++ b/typescript/src/tools/dashboards/getAll.ts
@@ -1,6 +1,7 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { DashboardGetAllSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = DashboardGetAllSchema;
 
@@ -22,10 +23,7 @@ export const getAllHandler = async (context: Context, params: Params) => {
 
 const tool = (): Tool<typeof schema> => ({
 	name: "dashboards-get-all",
-	description: `
-        - Get all dashboards in the project with optional filtering.
-        - Can filter by pinned status, search term, or pagination.
-    `,
+	description: getToolDefinition("dashboards-get-all").description,
 	schema,
 	handler: getAllHandler,
 });

--- a/typescript/src/tools/dashboards/update.ts
+++ b/typescript/src/tools/dashboards/update.ts
@@ -1,7 +1,8 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { getProjectBaseUrl } from "@/lib/utils/api";
 import { DashboardUpdateSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = DashboardUpdateSchema;
 
@@ -28,10 +29,7 @@ export const updateHandler = async (context: Context, params: Params) => {
 
 const tool = (): Tool<typeof schema> => ({
 	name: "dashboard-update",
-	description: `
-        - Update an existing dashboard by ID.
-        - Can update name, description, pinned status or tags.
-    `,
+	description: getToolDefinition("dashboard-update").description,
 	schema,
 	handler: updateHandler,
 });

--- a/typescript/src/tools/documentation/searchDocs.ts
+++ b/typescript/src/tools/documentation/searchDocs.ts
@@ -1,7 +1,8 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { docsSearch } from "@/inkeepApi";
 import { DocumentationSearchSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = DocumentationSearchSchema;
 
@@ -25,12 +26,11 @@ export const searchDocsHandler = async (context: Context, params: Params) => {
 	return { content: [{ type: "text", text: resultText }] };
 };
 
+const definition = getToolDefinition("docs-search");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "docs-search",
-	description: `
-        - Use this tool to search the PostHog documentation for information that can help the user with their request. 
-        - Use it as a fallback when you cannot answer the user's request using other tools in this MCP.
-    `,
+	description: definition.description,
 	schema,
 	handler: searchDocsHandler,
 });

--- a/typescript/src/tools/errorTracking/errorDetails.ts
+++ b/typescript/src/tools/errorTracking/errorDetails.ts
@@ -1,6 +1,7 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { ErrorTrackingDetailsSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = ErrorTrackingDetailsSchema;
 
@@ -30,11 +31,11 @@ export const errorDetailsHandler = async (context: Context, params: Params) => {
 	};
 };
 
+const definition = getToolDefinition("error-details");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "error-details",
-	description: `
-        - Use this tool to get the details of an error in the project.
-    `,
+	description: definition.description,
 	schema,
 	handler: errorDetailsHandler,
 });

--- a/typescript/src/tools/errorTracking/listErrors.ts
+++ b/typescript/src/tools/errorTracking/listErrors.ts
@@ -1,6 +1,7 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { ErrorTrackingListSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = ErrorTrackingListSchema;
 
@@ -33,11 +34,11 @@ export const listErrorsHandler = async (context: Context, params: Params) => {
 	};
 };
 
+const definition = getToolDefinition("list-errors");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "list-errors",
-	description: `
-        - Use this tool to list errors in the project.
-    `,
+	description: definition.description,
 	schema,
 	handler: listErrorsHandler,
 });

--- a/typescript/src/tools/featureFlags/create.ts
+++ b/typescript/src/tools/featureFlags/create.ts
@@ -1,7 +1,8 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { getProjectBaseUrl } from "@/lib/utils/api";
 import { FeatureFlagCreateSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = FeatureFlagCreateSchema;
 
@@ -29,13 +30,11 @@ export const createHandler = async (context: Context, params: Params) => {
 	};
 };
 
+const definition = getToolDefinition("create-feature-flag");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "create-feature-flag",
-	description: `Creates a new feature flag in the project. Once you have created a feature flag, you should:
-     - Ask the user if they want to add it to their codebase
-     - Use the "search-docs" tool to find documentation on how to add feature flags to the codebase (search for the right language / framework)
-     - Clarify where it should be added and then add it.
-    `,
+	description: definition.description,
 	schema,
 	handler: createHandler,
 });

--- a/typescript/src/tools/featureFlags/delete.ts
+++ b/typescript/src/tools/featureFlags/delete.ts
@@ -1,6 +1,7 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { FeatureFlagDeleteSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = FeatureFlagDeleteSchema;
 
@@ -33,11 +34,11 @@ export const deleteHandler = async (context: Context, params: Params) => {
 	};
 };
 
+const definition = getToolDefinition("delete-feature-flag");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "delete-feature-flag",
-	description: `
-        - Use this tool to delete a feature flag in the project.
-    `,
+	description: definition.description,
 	schema,
 	handler: deleteHandler,
 });

--- a/typescript/src/tools/featureFlags/getAll.ts
+++ b/typescript/src/tools/featureFlags/getAll.ts
@@ -1,6 +1,7 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { FeatureFlagGetAllSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = FeatureFlagGetAllSchema;
 
@@ -17,11 +18,11 @@ export const getAllHandler = async (context: Context, _params: Params) => {
 	return { content: [{ type: "text", text: JSON.stringify(flagsResult.data) }] };
 };
 
+const definition = getToolDefinition("feature-flag-get-all");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "feature-flag-get-all",
-	description: `
-        - Use this tool to get all feature flags in the project.
-    `,
+	description: definition.description,
 	schema,
 	handler: getAllHandler,
 });

--- a/typescript/src/tools/featureFlags/getDefinition.ts
+++ b/typescript/src/tools/featureFlags/getDefinition.ts
@@ -1,6 +1,7 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { FeatureFlagGetDefinitionSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = FeatureFlagGetDefinitionSchema;
 
@@ -64,13 +65,11 @@ export const getDefinitionHandler = async (context: Context, { flagId, flagKey }
 	};
 };
 
+const definition = getToolDefinition("feature-flag-get-definition");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "feature-flag-get-definition",
-	description: `
-        - Use this tool to get the definition of a feature flag. 
-        - You can provide either the flagId or the flagKey. 
-        - If you provide both, the flagId will be used.
-    `,
+	description: definition.description,
 	schema,
 	handler: getDefinitionHandler,
 });

--- a/typescript/src/tools/featureFlags/update.ts
+++ b/typescript/src/tools/featureFlags/update.ts
@@ -1,7 +1,8 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { getProjectBaseUrl } from "@/lib/utils/api";
 import { FeatureFlagUpdateSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = FeatureFlagUpdateSchema;
 
@@ -30,12 +31,11 @@ export const updateHandler = async (context: Context, params: Params) => {
 	};
 };
 
+const definition = getToolDefinition("update-feature-flag");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "update-feature-flag",
-	description: `Update a new feature flag in the project.
-    - To enable a feature flag, you should make sure it is active and the rollout percentage is set to 100 for the group you want to target.
-    - To disable a feature flag, you should make sure it is inactive, you can keep the rollout percentage as it is.
-    `,
+	description: definition.description,
 	schema,
 	handler: updateHandler,
 });

--- a/typescript/src/tools/insights/create.ts
+++ b/typescript/src/tools/insights/create.ts
@@ -1,7 +1,8 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { getProjectBaseUrl } from "@/lib/utils/api";
 import { InsightCreateSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = InsightCreateSchema;
 
@@ -23,28 +24,11 @@ export const createHandler = async (context: Context, params: Params) => {
 	return { content: [{ type: "text", text: JSON.stringify(insightWithUrl) }] };
 };
 
+const definition = getToolDefinition("insight-create-from-query");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "insight-create-from-query",
-	description: `
-        - You can use this to save a query as an insight. You should only do this with a valid query that you have seen, or one you have modified slightly.
-        - If the user wants to see data, you should use the "get-sql-insight" tool to get that data instead.
-        - An insight requires a name, query, and other optional properties.
-        - The query should use HogQL, which is a variant of Clickhouse SQL. Here is an example query:
-        Here is an example of a valid query:
-        {
-            "kind": "DataVisualizationNode",
-            "source": {
-                "kind": "HogQLQuery",
-                "query": "SELECT\\n  event,\\n  count() AS event_count\\nFROM\\n  events\\nWHERE\\n  timestamp >= now() - INTERVAL 7 day\\nGROUP BY\\n  event\\nORDER BY\\n  event_count DESC\\nLIMIT 10",
-                "explain": true,
-                "filters": {
-                    "dateRange": {
-                        "date_from": "-7d"
-                    }
-                }
-            },
-        }
-    `,
+	description: definition.description,
 	schema,
 	handler: createHandler,
 });

--- a/typescript/src/tools/insights/delete.ts
+++ b/typescript/src/tools/insights/delete.ts
@@ -1,6 +1,7 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { InsightDeleteSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = InsightDeleteSchema;
 
@@ -18,11 +19,11 @@ export const deleteHandler = async (context: Context, params: Params) => {
 	return { content: [{ type: "text", text: JSON.stringify(result.data) }] };
 };
 
+const definition = getToolDefinition("insight-delete");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "insight-delete",
-	description: `
-        - Delete an insight by ID (soft delete - marks as deleted).
-    `,
+	description: definition.description,
 	schema,
 	handler: deleteHandler,
 });

--- a/typescript/src/tools/insights/get.ts
+++ b/typescript/src/tools/insights/get.ts
@@ -1,7 +1,8 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { getProjectBaseUrl } from "@/lib/utils/api";
 import { InsightGetSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = InsightGetSchema;
 
@@ -23,11 +24,11 @@ export const getHandler = async (context: Context, params: Params) => {
 	return { content: [{ type: "text", text: JSON.stringify(insightWithUrl) }] };
 };
 
+const definition = getToolDefinition("insight-get");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "insight-get",
-	description: `
-        - Get a specific insight by ID.
-    `,
+	description: definition.description,
 	schema,
 	handler: getHandler,
 });

--- a/typescript/src/tools/insights/getAll.ts
+++ b/typescript/src/tools/insights/getAll.ts
@@ -1,7 +1,8 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { getProjectBaseUrl } from "@/lib/utils/api";
 import { InsightGetAllSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = InsightGetAllSchema;
 
@@ -24,12 +25,11 @@ export const getAllHandler = async (context: Context, params: Params) => {
 	return { content: [{ type: "text", text: JSON.stringify(insightsWithUrls) }] };
 };
 
+const definition = getToolDefinition("insights-get-all");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "insights-get-all",
-	description: `
-        - Get all insights in the project with optional filtering.
-        - Can filter by saved status, favorited status, or search term.
-    `,
+	description: definition.description,
 	schema,
 	handler: getAllHandler,
 });

--- a/typescript/src/tools/insights/getSqlInsight.ts
+++ b/typescript/src/tools/insights/getSqlInsight.ts
@@ -1,6 +1,7 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { InsightGetSqlSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = InsightGetSqlSchema;
 
@@ -11,6 +12,7 @@ export const getSqlInsightHandler = async (context: Context, params: Params) => 
 	const projectId = await context.getProjectId();
 
 	const result = await context.api.insights({ projectId }).sqlInsight({ query });
+
 	if (!result.success) {
 		throw new Error(`Failed to execute SQL insight: ${result.error.message}`);
 	}
@@ -28,16 +30,11 @@ export const getSqlInsightHandler = async (context: Context, params: Params) => 
 	return { content: [{ type: "text", text: JSON.stringify(result.data) }] };
 };
 
+const definition = getToolDefinition("get-sql-insight");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "get-sql-insight",
-	description: `
-        - Queries project's PostHog data warehouse based on a provided natural language question - don't provide SQL query as input but describe the output you want.
-        - Data warehouse schema includes data like events and persons.
-        - Use this tool to get a quick answer to a question about the data in the project, which can't be answered using other, more dedicated tools.
-        - Fetches the result as a Server-Sent Events (SSE) stream and provides the concatenated data content.
-        - When giving the results back to the user, first show the SQL query that was used, then briefly explain the query, then provide results in reasily readable format.
-        - You should also offer to save the query as an insight if the user wants to.
-    `,
+	description: definition.description,
 	schema,
 	handler: getSqlInsightHandler,
 });

--- a/typescript/src/tools/insights/update.ts
+++ b/typescript/src/tools/insights/update.ts
@@ -1,7 +1,8 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { getProjectBaseUrl } from "@/lib/utils/api";
 import { InsightUpdateSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = InsightUpdateSchema;
 
@@ -27,12 +28,11 @@ export const updateHandler = async (context: Context, params: Params) => {
 	return { content: [{ type: "text", text: JSON.stringify(insightWithUrl) }] };
 };
 
+const definition = getToolDefinition("insight-update");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "insight-update",
-	description: `
-        - Update an existing insight by ID.
-        - Can update name, description, filters, and other properties.
-    `,
+	description: definition.description,
 	schema,
 	handler: updateHandler,
 });

--- a/typescript/src/tools/llmObservability/getLLMCosts.ts
+++ b/typescript/src/tools/llmObservability/getLLMCosts.ts
@@ -1,6 +1,7 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { LLMObservabilityGetCostsSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = LLMObservabilityGetCostsSchema;
 
@@ -42,22 +43,11 @@ export const getLLMCostsHandler = async (context: Context, params: Params) => {
 	};
 };
 
+const definition = getToolDefinition("get-llm-total-costs-for-project");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "get-llm-total-costs-for-project",
-	description: `
-        - Fetches the total LLM daily costs for each model for a project over a given number of days.
-        - If no number of days is provided, it defaults to 7.
-        - The results are sorted by model name.
-        - The total cost is rounded to 4 decimal places.
-        - The query is executed against the project's data warehouse.
-        - Show the results as a Markdown formatted table with the following information for each model:
-            - Model name
-            - Total cost in USD
-            - Each day's date
-            - Each day's cost in USD
-        - Write in bold the model name with the highest total cost.
-        - Properly render the markdown table in the response.
-    `,
+	description: definition.description,
 	schema,
 	handler: getLLMCostsHandler,
 });

--- a/typescript/src/tools/organizations/getDetails.ts
+++ b/typescript/src/tools/organizations/getDetails.ts
@@ -1,6 +1,7 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { OrganizationGetDetailsSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = OrganizationGetDetailsSchema;
 
@@ -20,11 +21,11 @@ export const getDetailsHandler = async (context: Context, _params: Params) => {
 	};
 };
 
+const definition = getToolDefinition("organization-details-get");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "organization-details-get",
-	description: `
-        - Use this tool to get the details of the active organization.
-    `,
+	description: definition.description,
 	schema,
 	handler: getDetailsHandler,
 });

--- a/typescript/src/tools/organizations/getOrganizations.ts
+++ b/typescript/src/tools/organizations/getOrganizations.ts
@@ -1,6 +1,7 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { OrganizationGetAllSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = OrganizationGetAllSchema;
 
@@ -17,11 +18,11 @@ export const getOrganizationsHandler = async (context: Context, _params: Params)
 	};
 };
 
+const definition = getToolDefinition("organizations-get");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "organizations-get",
-	description: `
-        - Use this tool to get the organizations the user has access to.
-    `,
+	description: definition.description,
 	schema,
 	handler: getOrganizationsHandler,
 });

--- a/typescript/src/tools/organizations/setActive.ts
+++ b/typescript/src/tools/organizations/setActive.ts
@@ -1,6 +1,7 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { OrganizationSetActiveSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = OrganizationSetActiveSchema;
 
@@ -15,11 +16,11 @@ export const setActiveHandler = async (context: Context, params: Params) => {
 	};
 };
 
+const definition = getToolDefinition("organization-set-active");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "organization-set-active",
-	description: `
-        - Use this tool to set the active organization.
-    `,
+	description: definition.description,
 	schema,
 	handler: setActiveHandler,
 });

--- a/typescript/src/tools/projects/getProjects.ts
+++ b/typescript/src/tools/projects/getProjects.ts
@@ -1,6 +1,7 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { ProjectGetAllSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = ProjectGetAllSchema;
 
@@ -19,12 +20,11 @@ export const getProjectsHandler = async (context: Context, _params: Params) => {
 	};
 };
 
+const definition = getToolDefinition("projects-get");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "projects-get",
-	description: `
-        - Fetches projects that the user has access to - the orgId is optional. 
-        - Use this tool before you use any other tools (besides organization-* and docs-search) to allow user to select the project they want to use for subsequent requests.
-    `,
+	description: definition.description,
 	schema,
 	handler: getProjectsHandler,
 });

--- a/typescript/src/tools/projects/propertyDefinitions.ts
+++ b/typescript/src/tools/projects/propertyDefinitions.ts
@@ -1,6 +1,7 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { ProjectPropertyDefinitionsSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = ProjectPropertyDefinitionsSchema;
 
@@ -19,11 +20,11 @@ export const propertyDefinitionsHandler = async (context: Context, _params: Para
 	};
 };
 
+const definition = getToolDefinition("property-definitions");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "property-definitions",
-	description: `
-        - Use this tool to get the property definitions of the active project.
-    `,
+	description: definition.description,
 	schema,
 	handler: propertyDefinitionsHandler,
 });

--- a/typescript/src/tools/projects/setActive.ts
+++ b/typescript/src/tools/projects/setActive.ts
@@ -1,6 +1,7 @@
-import type { z } from "zod";
-import type { Context, Tool } from "@/tools/types";
 import { ProjectSetActiveSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
 
 const schema = ProjectSetActiveSchema;
 
@@ -16,11 +17,11 @@ export const setActiveHandler = async (context: Context, params: Params) => {
 	};
 };
 
+const definition = getToolDefinition("project-set-active");
+
 const tool = (): Tool<typeof schema> => ({
 	name: "project-set-active",
-	description: `
-        - Use this tool to set the active project.
-    `,
+	description: definition.description,
 	schema,
 	handler: setActiveHandler,
 });

--- a/typescript/src/tools/toolDefinitions.ts
+++ b/typescript/src/tools/toolDefinitions.ts
@@ -1,0 +1,19 @@
+import toolDefinitionsJson from "../../../schema/tool-definitions.json";
+
+export interface ToolDefinition {
+	description: string;
+}
+
+export type ToolDefinitions = Record<string, ToolDefinition>;
+
+const toolDefinitions: ToolDefinitions = toolDefinitionsJson;
+
+export default toolDefinitions;
+
+export function getToolDefinition(toolName: string): ToolDefinition {
+	const definition = toolDefinitions[toolName];
+	if (!definition) {
+		throw new Error(`Tool definition not found for: ${toolName}`);
+	}
+	return definition;
+}


### PR DESCRIPTION
We should be consistent with these, this uses a JSON file to store the tool descriptions and uses the same ones across ts / python