### PR TITLE
chore: include tiles in dashboard response

### DIFF
--- a/schema/tool-definitions.json
+++ b/schema/tool-definitions.json
@@ -15,9 +15,9 @@
 		"summary": "Delete a dashboard by ID."
 	},
 	"dashboard-get": {
-		"description": "Get a specific dashboard by ID.",
+		"description": "Get a specific dashboard by ID. The response will include insights / tiles that are on the dashboard.",
 		"category": "Dashboards",
-		"summary": "Get a specific dashboard by ID."
+		"summary": "Get a specific dashboard by ID, including insights that are on the dashboard."
 	},
 	"dashboards-get-all": {
 		"description": "Get all dashboards in the project with optional filtering. Can filter by pinned status, search term, or pagination.",

--- a/typescript/src/api/client.ts
+++ b/typescript/src/api/client.ts
@@ -615,6 +615,7 @@ export class ApiClient {
 					id: z.number(),
 					name: z.string(),
 					description: z.string().nullish(),
+					tiles: z.array(z.any()),
 				});
 
 				return this.fetchWithSchema(


### PR DESCRIPTION
It's helpful to return what insights are on a dashboard when we fetch it