### PR TITLE
chore: reduce output size of get-dashboard

### DIFF
--- a/typescript/src/api/client.ts
+++ b/typescript/src/api/client.ts
@@ -6,6 +6,8 @@ import {
 	CreateDashboardInputSchema,
 	type ListDashboardsData,
 	ListDashboardsSchema,
+	type SimpleDashboard,
+	SimpleDashboardSchema,
 } from "@/schema/dashboards";
 import type { Experiment } from "@/schema/experiments";
 import { ExperimentSchema } from "@/schema/experiments";
@@ -608,19 +610,10 @@ export class ApiClient {
 
 			get: async ({
 				dashboardId,
-			}: { dashboardId: number }): Promise<
-				Result<{ id: number; name: string; description?: string | null | undefined }>
-			> => {
-				const simpleDashboardSchema = z.object({
-					id: z.number(),
-					name: z.string(),
-					description: z.string().nullish(),
-					tiles: z.array(z.any()),
-				});
-
+			}: { dashboardId: number }): Promise<Result<SimpleDashboard>> => {
 				return this.fetchWithSchema(
 					`${this.baseUrl}/api/projects/${projectId}/dashboards/${dashboardId}/`,
-					simpleDashboardSchema,
+					SimpleDashboardSchema,
 				);
 			},
 

--- a/typescript/src/schema/dashboards.ts
+++ b/typescript/src/schema/dashboards.ts
@@ -1,4 +1,25 @@
 import { z } from "zod";
+import { QuerySchema } from "./query";
+
+export const DashboardTileSchema = z.object({
+	insight: z.object({
+		short_id: z.string(),
+		name: z.string(),
+		derived_name: z.string().nullable(),
+		description: z.string().nullable(),
+		query: QuerySchema,
+		created_at: z.string().nullish(),
+		updated_at: z.string().nullish(),
+		favorited: z.boolean().nullish(),
+		saved: z.boolean().nullish(),
+		tags: z.array(z.string()).nullish(),
+	}),
+	order: z.number(),
+	color: z.string().nullish(),
+	layouts: z.record(z.any()).nullish(),
+	last_refresh: z.string().nullish(),
+	is_cached: z.boolean().nullish(),
+});
 
 // Base dashboard schema from PostHog API
 export const DashboardSchema = z.object({
@@ -18,7 +39,14 @@ export const DashboardSchema = z.object({
 	filters: z.record(z.any()).nullish(),
 	variables: z.record(z.any()).nullish(),
 	tags: z.array(z.string()).nullish(),
-	tiles: z.array(z.record(z.any())).nullish(),
+	tiles: z.array(DashboardTileSchema).nullish(),
+});
+
+export const SimpleDashboardSchema = DashboardSchema.pick({
+	id: true,
+	name: true,
+	description: true,
+	tiles: true,
 });
 
 // Input schema for creating dashboards
@@ -57,3 +85,4 @@ export type CreateDashboardInput = z.infer<typeof CreateDashboardInputSchema>;
 export type UpdateDashboardInput = z.infer<typeof UpdateDashboardInputSchema>;
 export type ListDashboardsData = z.infer<typeof ListDashboardsSchema>;
 export type AddInsightToDashboardInput = z.infer<typeof AddInsightToDashboardSchema>;
+export type SimpleDashboard = z.infer<typeof SimpleDashboardSchema>;

--- a/typescript/src/schema/query.ts
+++ b/typescript/src/schema/query.ts
@@ -29,6 +29,8 @@ export const InsightQuerySchema = z.object({
 	source: HogQLQuerySchema,
 });
 
+export const QuerySchema = z.any();
+
 export type InsightQuery = z.infer<typeof InsightQuerySchema>;
 export type HogQLQuery = z.infer<typeof HogQLQuerySchema>;
 export type HogQLFilters = z.infer<typeof HogQLFiltersSchema>;


### PR DESCRIPTION
We can strip some unnecessary fields to avoid bloating the context window