### PR TITLE
feat(experiments): adding tool to get the experiment details.

### DIFF
--- a/python/schema/tool_inputs.py
+++ b/python/schema/tool_inputs.py
@@ -150,6 +150,16 @@ class ExperimentGetAllSchema(BaseModel):
     )
 
 
+class ExperimentGetSchema(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    experimentId: float
+    """
+    The ID of the experiment to retrieve
+    """
+
+
 class Operator(StrEnum):
     EXACT = "exact"
     IS_NOT = "is_not"

--- a/schema/tool-definitions.json
+++ b/schema/tool-definitions.json
@@ -74,6 +74,11 @@
 		"category": "Experiments",
 		"summary": "Get all experiments in the project."
 	},
+	"experiment-get": {
+		"description": "Get details of a specific experiment by ID.",
+		"category": "Experiments",
+		"summary": "Get details of a specific experiment."
+	},
 	"insight-create-from-query": {
 		"description": "Save a query as an insight. You should only do this with a valid query that you have seen, or one you have modified slightly. If the user wants to see data, you should use the \"get-sql-insight\" tool to get that data instead. An insight requires a name, query, and other optional properties. The query should use HogQL, which is a variant of Clickhouse SQL.",
 		"category": "Insights & analytics",

--- a/schema/tool-inputs.json
+++ b/schema/tool-inputs.json
@@ -227,6 +227,19 @@
       "properties": {},
       "additionalProperties": false
     },
+    "ExperimentGetSchema": {
+      "type": "object",
+      "properties": {
+        "experimentId": {
+          "type": "number",
+          "description": "The ID of the experiment to retrieve"
+        }
+      },
+      "required": [
+        "experimentId"
+      ],
+      "additionalProperties": false
+    },
     "FeatureFlagCreateSchema": {
       "type": "object",
       "properties": {

--- a/typescript/src/api/client.ts
+++ b/typescript/src/api/client.ts
@@ -196,6 +196,15 @@ export class ApiClient {
 					return { success: false, error: error as Error };
 				}
 			},
+
+			get: async ({
+				experimentId,
+			}: { experimentId: number }): Promise<Result<Experiment>> => {
+				return this.fetchWithSchema(
+					`${this.baseUrl}/api/projects/${projectId}/experiments/${experimentId}/`,
+					ExperimentSchema,
+				);
+			},
 		};
 	}
 

--- a/typescript/src/schema/tool-inputs.ts
+++ b/typescript/src/schema/tool-inputs.ts
@@ -44,6 +44,10 @@ export const ErrorTrackingListSchema = ListErrorsSchema;
 
 export const ExperimentGetAllSchema = z.object({});
 
+export const ExperimentGetSchema = z.object({
+	experimentId: z.number().describe("The ID of the experiment to retrieve"),
+});
+
 export const FeatureFlagCreateSchema = z.object({
 	name: z.string(),
 	key: z.string(),

--- a/typescript/src/tools/experiments/get.ts
+++ b/typescript/src/tools/experiments/get.ts
@@ -1,0 +1,39 @@
+import { ExperimentGetSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
+
+const schema = ExperimentGetSchema;
+
+type Params = z.infer<typeof schema>;
+
+export const getHandler = async (context: Context, params: Params) => {
+	const projectId = await context.stateManager.getProjectId();
+
+	const result = await context.api.experiments({ projectId }).get({
+		experimentId: params.experimentId,
+	});
+
+	if (!result.success) {
+		throw new Error(`Failed to get experiment: ${result.error.message}`);
+	}
+
+	return { content: [{ type: "text", text: JSON.stringify(result.data) }] };
+};
+
+const definition = getToolDefinition("experiment-get");
+
+const tool = (): Tool<typeof schema> => ({
+	name: "experiment-get",
+	description: definition.description,
+	schema,
+	handler: getHandler,
+	annotations: {
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+		readOnlyHint: true,
+	},
+});
+
+export default tool;

--- a/typescript/src/tools/index.ts
+++ b/typescript/src/tools/index.ts
@@ -31,6 +31,7 @@ import listErrors from "./errorTracking/listErrors";
 
 // Experiments
 import getAllExperiments from "./experiments/getAll";
+import getExperiment from "./experiments/get";
 
 import createInsight from "./insights/create";
 import deleteInsight from "./insights/delete";
@@ -79,6 +80,7 @@ export const getToolsFromContext = (context: Context): Tool<ZodObjectAny>[] => [
 
 	// Experiments
 	getAllExperiments(),
+	getExperiment(),
 
 	// Insights
 	getAllInsights(),


### PR DESCRIPTION
## Problem

We are missing a tool to get the experiment details 😭 

## Changes

We are adding a new `get` tool for experiments

## How did you test this code?

| Claude Code |
| - |
| <img width="1512" height="807" alt="image" src="https://github.com/user-attachments/assets/b9df8344-1867-4136-a08a-55aa426c93a5" /> |

![cat-type-small](https://github.com/user-attachments/assets/2f6fd9f2-e5c3-462a-8c8c-d82f5f8730e3)