### PR TITLE
fix: try set path as typescript for package version detection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Check package version and detect an update
         id: check-package-version
         uses: PostHog/check-package-version@v2
+        with:
+          path: typescript/
 
   release:
     name: Publish release if new version


### PR DESCRIPTION
This is trying to publish the package from the root, it should use the typescript folder instead.