### PR TITLE
feat: dockerize mcp server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Use a lightweight Node.js image
+FROM node:20-slim
+
+# Set the working directory inside the container
+WORKDIR /usr/src/app
+
+# Install mcp-remote globally to avoid npx overhead on each run
+RUN npm install -g mcp-remote@latest
+
+# Set default environment variable for POSTHOG_REMOTE_MCP_URL
+ENV POSTHOG_REMOTE_MCP_URL=https://mcp.posthog.com/mcp
+
+# The entrypoint will run mcp-remote with proper stdio handling
+# POSTHOG_AUTH_HEADER should be just the token (e.g., phx_...), we'll add "Bearer " prefix
+ENTRYPOINT ["sh", "-c", "mcp-remote \"${POSTHOG_REMOTE_MCP_URL}\" --header \"Authorization:Bearer ${POSTHOG_AUTH_HEADER}\""]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,56 @@ npx @posthog/wizard@latest mcp add
 }
 ```
 
+### Docker install
+
+If you prefer to use Docker instead of running npx directly:
+
+1. Build the Docker image:
+```bash
+pnpm docker:build
+# or
+docker build -t posthog-mcp .
+```
+
+2. Configure your MCP client with Docker:
+```json
+{
+  "mcpServers": {
+    "posthog": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "--env",
+        "POSTHOG_AUTH_HEADER=${POSTHOG_AUTH_HEADER}",
+        "--env",
+        "POSTHOG_REMOTE_MCP_URL=${POSTHOG_REMOTE_MCP_URL:-https://mcp.posthog.com/mcp}",
+        "posthog-mcp"
+      ],
+      "env": {
+        "POSTHOG_AUTH_HEADER": "Bearer {INSERT_YOUR_PERSONAL_API_KEY_HERE}",
+        "POSTHOG_REMOTE_MCP_URL": "https://mcp.posthog.com/mcp"
+      }
+    }
+  }
+}
+```
+
+3. Test Docker with MCP Inspector:
+```bash
+pnpm docker:inspector
+# or
+npx @modelcontextprotocol/inspector docker run -i --rm --env POSTHOG_AUTH_HEADER=${POSTHOG_AUTH_HEADER} posthog-mcp
+```
+
+**Environment Variables:**
+- `POSTHOG_AUTH_HEADER`: Your PostHog API token (required)
+- `POSTHOG_REMOTE_MCP_URL`: The MCP server URL (optional, defaults to `https://mcp.posthog.com/mcp`)
+
+This approach allows you to use the PostHog MCP server without needing Node.js or npm installed locally.
+
 ### Example Prompts
 - What feature flags do I have active?
 - Add a new feature flag for our homepage redesign
@@ -90,7 +140,7 @@ INKEEP_API_KEY="..."
 
 ### Configuring the Model Context Protocol Inspector
 
-During development you can directly inspect the MCP tool call results using the [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector). 
+During development you can directly inspect the MCP tool call results using the [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector).
 
 You can run it using the following command:
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
 		"format:python": "cd python && uv run ruff format .",
 		"lint:python": "cd python && uv run ruff check --fix .",
 		"test:python": "cd python && uv run pytest tests/ -v",
-		"typecheck:python": "cd python && uvx ty check"
+		"typecheck:python": "cd python && uvx ty check",
+		"docker:build": "docker build -t posthog-mcp .",
+		"docker:run": "docker run -i --rm --env POSTHOG_AUTH_HEADER=${POSTHOG_AUTH_HEADER} --env POSTHOG_REMOTE_MCP_URL=${POSTHOG_REMOTE_MCP_URL:-https://mcp.posthog.com/mcp} posthog-mcp",
+		"docker:inspector": "npx @modelcontextprotocol/inspector docker run -i --rm --env POSTHOG_AUTH_HEADER=${POSTHOG_AUTH_HEADER} --env POSTHOG_REMOTE_MCP_URL=${POSTHOG_REMOTE_MCP_URL:-https://mcp.posthog.com/mcp} posthog-mcp"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",


### PR DESCRIPTION
Provides ability to run this MCP server inside a Docker container for folks who don't want to run a random npm package via `npx` directly in their CLI.