### PR TITLE
feat: improved event and property discovery

### DIFF
--- a/schema/tool-definitions.json
+++ b/schema/tool-definitions.json
@@ -139,10 +139,17 @@
 		"category": "Organization & project management",
 		"summary": "Fetches projects that the user has access to in the current organization."
 	},
-	"property-definitions": {
-		"description": "Get event and property definitions for the project.",
-		"category": "Organization & project management",
-		"summary": "Get event and property definitions for the project."
+	"event-definitions-list": {
+		"description": "List all event definitions in the project with optional filtering. Can filter by search term.",
+		"category": "Events & properties",
+		"summary": "List all event definitions in the project with optional filtering.",
+		"title": "List all events"
+	},
+	"event-properties-get": {
+		"description": "Get common properties for an event.",
+		"category": "Events & properties",
+		"summary": "Get common properties for an event.",
+		"title": "Get event properties"
 	},
 	"switch-project": {
 		"description": "Change the active project from the default project. You should only use this tool if the user asks you to change the project - otherwise, the default project will be used.",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -38,36 +38,47 @@
 		"test:watch": "vitest watch",
 		"typecheck": "tsc --noEmit"
 	},
-	"keywords": ["posthog", "mcp", "ai", "agents", "analytics", "feature-flags"],
+	"keywords": [
+		"posthog",
+		"mcp",
+		"ai",
+		"agents",
+		"analytics",
+		"feature-flags"
+	],
 	"author": "PostHog Inc.",
 	"license": "MIT",
 	"peerDependencies": {
-		"ai": "^5.0.0",
 		"@langchain/core": "^0.3.72",
 		"@langchain/openai": "^0.6.9",
+		"ai": "^5.0.0",
 		"langchain": "^0.3.31"
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.17.3",
-		"ai": "^5.0.18",
 		"agents": "^0.0.113",
+		"ai": "^5.0.18",
 		"posthog-node": "^4.18.0",
 		"zod": "^3.24.4"
 	},
 	"devDependencies": {
 		"@langchain/core": "^0.3.72",
 		"@langchain/openai": "^0.6.9",
-		"@types/node": "^22.15.34",
 		"@types/dotenv": "^6.1.1",
+		"@types/node": "^22.15.34",
 		"dotenv": "^16.4.7",
 		"langchain": "^0.3.31",
 		"tsup": "^8.5.0",
 		"typescript": "^5.8.3",
+		"uuid": "^11.1.0",
 		"vite": "^5.0.0",
 		"vite-tsconfig-paths": "^5.1.4",
 		"vitest": "^3.2.4",
 		"wrangler": "^4.14.4",
 		"zod-to-json-schema": "^3.24.6"
 	},
-	"files": ["dist", "README.md"]
+	"files": [
+		"dist",
+		"README.md"
+	]
 }

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -38,14 +38,7 @@
 		"test:watch": "vitest watch",
 		"typecheck": "tsc --noEmit"
 	},
-	"keywords": [
-		"posthog",
-		"mcp",
-		"ai",
-		"agents",
-		"analytics",
-		"feature-flags"
-	],
+	"keywords": ["posthog", "mcp", "ai", "agents", "analytics", "feature-flags"],
 	"author": "PostHog Inc.",
 	"license": "MIT",
 	"peerDependencies": {
@@ -77,8 +70,5 @@
 		"wrangler": "^4.14.4",
 		"zod-to-json-schema": "^3.24.6"
 	},
-	"files": [
-		"dist",
-		"README.md"
-	]
+	"files": ["dist", "README.md"]
 }

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
       vite:
         specifier: ^5.0.0
         version: 5.4.19(@types/node@22.17.2)
@@ -2051,6 +2054,10 @@ packages:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
 
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -3934,6 +3941,8 @@ snapshots:
       react: 19.1.1
 
   uuid@10.0.0: {}
+
+  uuid@11.1.0: {}
 
   vary@1.1.2: {}
 

--- a/typescript/src/lib/utils/api.ts
+++ b/typescript/src/lib/utils/api.ts
@@ -19,6 +19,8 @@ export const withPagination = async <T>(
 
 	const data = await response.json();
 
+	console.log("Fetched data:", data);
+
 	const responseSchema = ApiListResponseSchema<z.ZodType<T>>(dataSchema);
 
 	const parsedData = responseSchema.parse(data);

--- a/typescript/src/schema/api.ts
+++ b/typescript/src/schema/api.ts
@@ -13,7 +13,26 @@ export const ApiPropertyDefinitionSchema = z.object({
 	verified_at: z.string().nullish(),
 	verified_by: z.string().nullish(),
 	hidden: z.boolean().nullish(),
-	tags: z.array(z.string()).default([]),
+	tags: z.array(z.string()).nullish(),
+});
+
+export const ApiEventDefintionSchema = z.object({
+	id: z.string().uuid(),
+	name: z.string(),
+	owner: z.string().nullish(),
+	description: z.string().nullish(),
+	created_at: z.string().nullish(),
+	updated_at: z.string().nullish(),
+	updated_by: z.string().nullish(),
+	last_seen_at: z.string().nullish(),
+	verified: z.boolean().nullish(),
+	verified_at: z.string().nullish(),
+	verified_by: z.string().nullish(),
+	hidden: z.boolean().nullish(),
+	is_action: z.boolean().nullish(),
+	post_to_slack: z.boolean().nullish(),
+	default_columns: z.array(z.string().nullish()).nullish(),
+	tags: z.array(z.string().nullish()).nullish(),
 });
 
 export const ApiListResponseSchema = <T extends z.ZodType>(dataSchema: T) =>
@@ -23,3 +42,6 @@ export const ApiListResponseSchema = <T extends z.ZodType>(dataSchema: T) =>
 		previous: z.string().nullish(),
 		results: z.array(dataSchema),
 	});
+
+export type ApiPropertyDefinition = z.infer<typeof ApiPropertyDefinitionSchema>;
+export type ApiEventDefinition = z.infer<typeof ApiEventDefintionSchema>;

--- a/typescript/src/schema/properties.ts
+++ b/typescript/src/schema/properties.ts
@@ -1,9 +1,18 @@
-import { type ApiListResponseSchema, ApiPropertyDefinitionSchema } from "@/schema/api";
+import {
+	ApiEventDefintionSchema,
+	type ApiListResponseSchema,
+	ApiPropertyDefinitionSchema,
+} from "@/schema/api";
 import type { z } from "zod";
 
 export const PropertyDefinitionSchema = ApiPropertyDefinitionSchema.pick({
 	name: true,
 	property_type: true,
+});
+
+export const EventDefinitionSchema = ApiEventDefintionSchema.pick({
+	name: true,
+	last_seen_at: true,
 });
 
 export type PropertyDefinition = z.infer<typeof ApiPropertyDefinitionSchema>;

--- a/typescript/src/schema/tool-inputs.ts
+++ b/typescript/src/schema/tool-inputs.ts
@@ -120,7 +120,11 @@ export const OrganizationSetActiveSchema = z.object({
 
 export const ProjectGetAllSchema = z.object({});
 
-export const ProjectPropertyDefinitionsSchema = z.object({});
+export const ProjectEventDefinitionsSchema = z.object({});
+
+export const ProjectPropertyDefinitionsSchema = z.object({
+	eventName: z.string().describe("Event name to filter properties by"),
+});
 
 export const ProjectSetActiveSchema = z.object({
 	projectId: z.number().int().positive(),

--- a/typescript/src/tools/index.ts
+++ b/typescript/src/tools/index.ts
@@ -52,6 +52,7 @@ import updateDashboard from "./dashboards/update";
 
 // LLM Observability
 import getLLMCosts from "./llmObservability/getLLMCosts";
+import eventDefinitions from "./projects/eventDefinitions";
 
 export const getToolsFromContext = (context: Context): Tool<ZodObjectAny>[] => [
 	// Feature Flags
@@ -70,6 +71,7 @@ export const getToolsFromContext = (context: Context): Tool<ZodObjectAny>[] => [
 	getProjects(),
 	setActiveProject(),
 	propertyDefinitions(),
+	eventDefinitions(),
 
 	// Documentation
 	...(context.env.INKEEP_API_KEY ? [searchDocs()] : []),

--- a/typescript/src/tools/projects/eventDefinitions.ts
+++ b/typescript/src/tools/projects/eventDefinitions.ts
@@ -1,0 +1,43 @@
+import { EventDefinitionSchema } from "@/schema/properties";
+import { ProjectEventDefinitionsSchema } from "@/schema/tool-inputs";
+import { getToolDefinition } from "@/tools/toolDefinitions";
+import type { Context, Tool } from "@/tools/types";
+import type { z } from "zod";
+
+const schema = ProjectEventDefinitionsSchema;
+
+type Params = z.infer<typeof schema>;
+
+export const eventDefinitionsHandler = async (context: Context, _params: Params) => {
+	const projectId = await context.stateManager.getProjectId();
+
+	const eventDefsResult = await context.api.projects().eventDefinitions({ projectId });
+
+	if (!eventDefsResult.success) {
+		throw new Error(`Failed to get event definitions: ${eventDefsResult.error.message}`);
+	}
+
+	const simplifiedEvents = eventDefsResult.data.map((def) => EventDefinitionSchema.parse(def));
+
+	return {
+		content: [{ type: "text", text: JSON.stringify(simplifiedEvents) }],
+	};
+};
+
+const definition = getToolDefinition("event-definitions-list");
+
+const tool = (): Tool<typeof schema> => ({
+	name: "event-definitions-list",
+	title: definition.title,
+	description: definition.description,
+	schema,
+	handler: eventDefinitionsHandler,
+	annotations: {
+		destructiveHint: false,
+		idempotentHint: true,
+		openWorldHint: true,
+		readOnlyHint: true,
+	},
+});
+
+export default tool;

--- a/typescript/src/tools/projects/eventDefinitions.ts
+++ b/typescript/src/tools/projects/eventDefinitions.ts
@@ -28,7 +28,6 @@ const definition = getToolDefinition("event-definitions-list");
 
 const tool = (): Tool<typeof schema> => ({
 	name: "event-definitions-list",
-	title: definition.title,
 	description: definition.description,
 	schema,
 	handler: eventDefinitionsHandler,

--- a/typescript/src/tools/projects/propertyDefinitions.ts
+++ b/typescript/src/tools/projects/propertyDefinitions.ts
@@ -1,3 +1,4 @@
+import { PropertyDefinitionSchema } from "@/schema/properties";
 import { ProjectPropertyDefinitionsSchema } from "@/schema/tool-inputs";
 import { getToolDefinition } from "@/tools/toolDefinitions";
 import type { Context, Tool } from "@/tools/types";
@@ -7,23 +8,35 @@ const schema = ProjectPropertyDefinitionsSchema;
 
 type Params = z.infer<typeof schema>;
 
-export const propertyDefinitionsHandler = async (context: Context, _params: Params) => {
+export const propertyDefinitionsHandler = async (context: Context, params: Params) => {
 	const projectId = await context.stateManager.getProjectId();
 
-	const propDefsResult = await context.api.projects().propertyDefinitions({ projectId });
+	const propDefsResult = await context.api.projects().propertyDefinitions({
+		projectId,
+		eventNames: [params.eventName],
+		excludeCoreProperties: true,
+		filterByEventNames: true,
+		isFeatureFlag: false,
+		limit: 100,
+	});
 
 	if (!propDefsResult.success) {
-		throw new Error(`Failed to get property definitions: ${propDefsResult.error.message}`);
+		throw new Error(
+			`Failed to get property definitions for event ${params.eventName}: ${propDefsResult.error.message}`,
+		);
 	}
+
+	const simplifiedProperties = PropertyDefinitionSchema.array().parse(propDefsResult.data);
+
 	return {
-		content: [{ type: "text", text: JSON.stringify(propDefsResult.data) }],
+		content: [{ type: "text", text: JSON.stringify(simplifiedProperties) }],
 	};
 };
 
-const definition = getToolDefinition("property-definitions");
+const definition = getToolDefinition("event-properties-get");
 
 const tool = (): Tool<typeof schema> => ({
-	name: "property-definitions",
+	name: "event-properties-get",
 	description: definition.description,
 	schema,
 	handler: propertyDefinitionsHandler,

--- a/typescript/tests/api/client.integration.test.ts
+++ b/typescript/tests/api/client.integration.test.ts
@@ -150,16 +150,14 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 		});
 
 		it("should get property definitions", async () => {
-			const result = await client
-				.projects()
-				.propertyDefinitions({ 
-					projectId: testProjectId,
-					eventNames: ["$pageview"],
-					excludeCoreProperties: true,
-					filterByEventNames: true,
-					isFeatureFlag: false,
-					limit: 100
-				});
+			const result = await client.projects().propertyDefinitions({
+				projectId: testProjectId,
+				eventNames: ["$pageview"],
+				excludeCoreProperties: true,
+				filterByEventNames: true,
+				isFeatureFlag: false,
+				limit: 100,
+			});
 
 			expect(result.success).toBe(true);
 
@@ -174,9 +172,7 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 		});
 
 		it("should get event definitions", async () => {
-			const result = await client
-				.projects()
-				.eventDefinitions({ projectId: testProjectId });
+			const result = await client.projects().eventDefinitions({ projectId: testProjectId });
 
 			expect(result.success).toBe(true);
 

--- a/typescript/tests/api/client.integration.test.ts
+++ b/typescript/tests/api/client.integration.test.ts
@@ -152,7 +152,14 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 		it("should get property definitions", async () => {
 			const result = await client
 				.projects()
-				.propertyDefinitions({ projectId: testProjectId });
+				.propertyDefinitions({ 
+					projectId: testProjectId,
+					eventNames: ["$pageview"],
+					excludeCoreProperties: true,
+					filterByEventNames: true,
+					isFeatureFlag: false,
+					limit: 100
+				});
 
 			expect(result.success).toBe(true);
 
@@ -162,6 +169,24 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 					const propDef = result.data[0];
 					expect(propDef).toHaveProperty("id");
 					expect(propDef).toHaveProperty("name");
+				}
+			}
+		});
+
+		it("should get event definitions", async () => {
+			const result = await client
+				.projects()
+				.eventDefinitions({ projectId: testProjectId });
+
+			expect(result.success).toBe(true);
+
+			if (result.success) {
+				expect(Array.isArray(result.data)).toBe(true);
+				if (result.data.length > 0) {
+					const eventDef = result.data[0];
+					expect(eventDef).toHaveProperty("id");
+					expect(eventDef).toHaveProperty("name");
+					expect(eventDef).toHaveProperty("last_seen_at");
 				}
 			}
 		});

--- a/typescript/tests/tools/projects.integration.test.ts
+++ b/typescript/tests/tools/projects.integration.test.ts
@@ -13,6 +13,7 @@ import getProjectsTool from "@/tools/projects/getProjects";
 import propertyDefinitionsTool from "@/tools/projects/propertyDefinitions";
 import setActiveProjectTool from "@/tools/projects/setActive";
 import type { Context } from "@/tools/types";
+import { v4 as uuidv4 } from "uuid";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 
 describe("Projects", { concurrent: false }, () => {
@@ -82,11 +83,13 @@ describe("Projects", { concurrent: false }, () => {
 		});
 	});
 
-	describe("property-definitions tool", () => {
+	describe("event-properties-get tool", () => {
 		const propertyDefsTool = propertyDefinitionsTool();
 
 		it.skip("should get property definitions for active project", async () => {
-			const result = await propertyDefsTool.handler(context, {});
+			const result = await propertyDefsTool.handler(context, {
+				eventName: "$pageview",
+			});
 			const propertyDefs = parseToolResponse(result);
 
 			expect(propertyDefs).toHaveProperty("event_properties");
@@ -99,7 +102,9 @@ describe("Projects", { concurrent: false }, () => {
 		});
 
 		it.skip("should return property definitions with proper structure", async () => {
-			const result = await propertyDefsTool.handler(context, {});
+			const result = await propertyDefsTool.handler(context, {
+				eventName: "$pageview",
+			});
 			const propertyDefs = parseToolResponse(result);
 
 			if (propertyDefs.event_properties.length > 0) {


### PR DESCRIPTION
At the moment, we were only exposing a property definition tool, this means events could only be discovered via existing insights, leading to the LLM making up events.

This adds an `event-definitions-list` tool to list event names along with when they were last used, and modifies the existing property definitions tool to require an `eventName` to be passed, and to filter only properties for that event.

It does not expose UUIDs for event names / properties to avoid the LLM trying to use those, or talk about them, as they aren't human readable.

