### PR TITLE
feat: add support for trends and funnels

### DIFF
--- a/python/schema/tool_inputs.py
+++ b/python/schema/tool_inputs.py
@@ -287,39 +287,363 @@ class DateRange(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    date_from: str
-    """
-    The start date of the date range. Could be a date string or a relative date string like '-7d'
-    """
-    date_to: str
-    """
-    The end date of the date range. Could be a date string or a relative date string like '-1d'
-    """
+    date_from: str | None = None
+    date_to: str | None = None
+    explicitDate: bool | None = None
 
 
-class Filters2(BaseModel):
+class Properties(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    dateRange: DateRange | None = None
+    key: str
+    value: str | float | list[str] | list[float] | None = None
+    operator: str | None = None
+    type: str | None = None
+
+
+class Type(StrEnum):
+    AND_ = "AND"
+    OR_ = "OR"
+
+
+class Value(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    key: str
+    value: str | float | list[str] | list[float] | None = None
+    operator: str | None = None
+    type: str | None = None
+
+
+class Properties1(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    type: Type
+    values: list[Value]
+
+
+class Properties2(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    type: Type
+    values: list[Value]
+
+
+class Interval(StrEnum):
+    HOUR = "hour"
+    DAY = "day"
+    WEEK = "week"
+    MONTH = "month"
+
+
+class Math(StrEnum):
+    TOTAL = "total"
+    DAU = "dau"
+    WEEKLY_ACTIVE = "weekly_active"
+    MONTHLY_ACTIVE = "monthly_active"
+    UNIQUE_SESSION = "unique_session"
+    FIRST_TIME_FOR_USER = "first_time_for_user"
+    FIRST_MATCHING_EVENT_FOR_USER = "first_matching_event_for_user"
+    AVG = "avg"
+    SUM = "sum"
+    MIN = "min"
+    MAX = "max"
+    MEDIAN = "median"
+    P75 = "p75"
+    P90 = "p90"
+    P95 = "p95"
+    P99 = "p99"
+
+
+class Properties3(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    key: str
+    value: str | float | list[str] | list[float] | None = None
+    operator: str | None = None
+    type: str | None = None
+
+
+class Properties4(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    type: Type
+    values: list[Value]
+
+
+class Properties5(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    type: Type
+    values: list[Value]
+
+
+class Series(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    custom_name: str | None = None
+    math: Math | None = None
+    math_property: str | None = None
+    properties: list[Properties3 | Properties4] | Properties5 | None = None
+    kind: Literal["EventsNode"] = "EventsNode"
+    event: str | None = None
+    limit: float | None = None
+
+
+class Display(StrEnum):
+    ACTIONS_LINE_GRAPH = "ActionsLineGraph"
+    ACTIONS_TABLE = "ActionsTable"
+    ACTIONS_PIE = "ActionsPie"
+    ACTIONS_BAR = "ActionsBar"
+    ACTIONS_BAR_VALUE = "ActionsBarValue"
+    WORLD_MAP = "WorldMap"
+    BOLD_NUMBER = "BoldNumber"
+
+
+class TrendsFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    display: Display | None = Display.ACTIONS_LINE_GRAPH
+    showLegend: bool | None = False
+
+
+class BreakdownType(StrEnum):
+    PERSON = "person"
+    EVENT = "event"
+
+
+class BreakdownFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    breakdown_type: BreakdownType | None = BreakdownType.EVENT
+    breakdown_limit: float | None = None
+    breakdown: str | float | list[str | float] | None = None
+
+
+class CompareFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    compare: bool | None = False
+    compare_to: str | None = None
 
 
 class Source(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
-    kind: Literal["HogQLQuery"] = "HogQLQuery"
-    query: str
-    explain: bool | None = None
-    filters: Filters2 | None = None
+    dateRange: DateRange | None = None
+    filterTestAccounts: bool | None = False
+    properties: list[Properties | Properties1] | Properties2 | None = []
+    kind: Literal["TrendsQuery"] = "TrendsQuery"
+    interval: Interval | None = Interval.DAY
+    series: list[Series]
+    trendsFilter: TrendsFilter | None = None
+    breakdownFilter: BreakdownFilter | None = None
+    compareFilter: CompareFilter | None = None
+    conversionGoal: Any = None
+
+
+class Properties6(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    key: str
+    value: str | float | list[str] | list[float] | None = None
+    operator: str | None = None
+    type: str | None = None
+
+
+class Properties7(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    type: Type
+    values: list[Value]
+
+
+class Properties8(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    type: Type
+    values: list[Value]
+
+
+class Properties9(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    key: str
+    value: str | float | list[str] | list[float] | None = None
+    operator: str | None = None
+    type: str | None = None
+
+
+class Properties10(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    type: Type
+    values: list[Value]
+
+
+class Properties11(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    type: Type
+    values: list[Value]
+
+
+class Series1(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    custom_name: str | None = None
+    math: Math | None = None
+    math_property: str | None = None
+    properties: list[Properties9 | Properties10] | Properties11 | None = None
+    kind: Literal["EventsNode"] = "EventsNode"
+    event: str | None = None
+    limit: float | None = None
+
+
+class Layout(StrEnum):
+    HORIZONTAL = "horizontal"
+    VERTICAL = "vertical"
+
+
+class BreakdownAttributionType(StrEnum):
+    FIRST_TOUCH = "first_touch"
+    LAST_TOUCH = "last_touch"
+    ALL_EVENTS = "all_events"
+
+
+class FunnelOrderType(StrEnum):
+    ORDERED = "ordered"
+    UNORDERED = "unordered"
+    STRICT = "strict"
+
+
+class FunnelVizType(StrEnum):
+    STEPS = "steps"
+    TIME_TO_CONVERT = "time_to_convert"
+    TRENDS = "trends"
+
+
+class FunnelWindowIntervalUnit(StrEnum):
+    MINUTE = "minute"
+    HOUR = "hour"
+    DAY = "day"
+    WEEK = "week"
+    MONTH = "month"
+
+
+class FunnelStepReference(StrEnum):
+    TOTAL = "total"
+    PREVIOUS = "previous"
+
+
+class FunnelsFilter(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    layout: Layout | None = Layout.VERTICAL
+    breakdownAttributionType: BreakdownAttributionType | None = BreakdownAttributionType.FIRST_TOUCH
+    breakdownAttributionValue: float | None = None
+    funnelToStep: float | None = None
+    funnelFromStep: float | None = None
+    funnelOrderType: FunnelOrderType | None = FunnelOrderType.ORDERED
+    funnelVizType: FunnelVizType | None = FunnelVizType.STEPS
+    funnelWindowInterval: float | None = 14
+    funnelWindowIntervalUnit: FunnelWindowIntervalUnit | None = FunnelWindowIntervalUnit.DAY
+    funnelStepReference: FunnelStepReference | None = FunnelStepReference.TOTAL
+
+
+class BreakdownFilter1(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    breakdown_type: BreakdownType | None = BreakdownType.EVENT
+    breakdown_limit: float | None = None
+    breakdown: str | float | list[str | float] | None = None
+
+
+class Source1(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dateRange: DateRange | None = None
+    filterTestAccounts: bool | None = False
+    properties: list[Properties6 | Properties7] | Properties8 | None = []
+    kind: Literal["FunnelsQuery"] = "FunnelsQuery"
+    interval: Interval | None = Interval.DAY
+    series: Annotated[list[Series1], Field(min_length=2)]
+    funnelsFilter: FunnelsFilter | None = None
+    breakdownFilter: BreakdownFilter1 | None = None
 
 
 class Query(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    kind: Literal["InsightVizNode"] = "InsightVizNode"
+    source: Source | Source1
+
+
+class Properties12(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    key: str
+    value: str | float | list[str] | list[float] | None = None
+    operator: str | None = None
+    type: str | None = None
+
+
+class Properties13(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    type: Type
+    values: list[Value]
+
+
+class Filters2(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    properties: list[Properties12 | Properties13] | None = None
+    dateRange: DateRange | None = None
+    filterTestAccounts: bool | None = None
+
+
+class Source2(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    kind: Literal["HogQLQuery"] = "HogQLQuery"
+    query: str
+    filters: Filters2 | None = None
+
+
+class Query1(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
     kind: Literal["DataVisualizationNode"] = "DataVisualizationNode"
-    source: Source
+    source: Source2
 
 
 class Data5(BaseModel):
@@ -327,9 +651,8 @@ class Data5(BaseModel):
         extra="forbid",
     )
     name: str
-    query: Query
+    query: Query | Query1
     description: str | None = None
-    saved: bool | None = True
     favorited: bool | None = False
     tags: list[str] | None = None
 
@@ -348,13 +671,22 @@ class InsightDeleteSchema(BaseModel):
     insightId: str
 
 
+class InsightGenerateHogQLFromQuestionSchema(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    question: Annotated[str, Field(max_length=1000)]
+    """
+    Your natural language query describing the SQL insight (max 1000 characters).
+    """
+
+
 class Data6(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
     limit: float | None = None
     offset: float | None = None
-    saved: bool | None = None
     favorited: bool | None = None
     search: str | None = None
 
@@ -373,16 +705,6 @@ class InsightGetSchema(BaseModel):
     insightId: str
 
 
-class InsightGetSqlSchema(BaseModel):
-    model_config = ConfigDict(
-        extra="forbid",
-    )
-    query: Annotated[str, Field(max_length=1000)]
-    """
-    Your natural language query describing the SQL insight (max 1000 characters).
-    """
-
-
 class InsightQuerySchema(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -398,7 +720,6 @@ class Data7(BaseModel):
     description: str | None = None
     filters: dict[str, Any] | None = None
     query: dict[str, Any] | None = None
-    saved: bool | None = None
     favorited: bool | None = None
     dashboard: float | None = None
     tags: list[str] | None = None

--- a/schema/tool-definitions.json
+++ b/schema/tool-definitions.json
@@ -95,8 +95,8 @@
 		"summary": "Get details of a specific experiment.",
 		"title": "Get experiment details"
 	},
-	"insight-create-from-query": {
-		"description": "Save a query as an insight. You should only do this with a valid query that you have seen, or one you have modified slightly. If the user wants to see data, you should use the \"get-sql-insight\" tool to get that data instead. An insight requires a name, query, and other optional properties. The query should use HogQL, which is a variant of Clickhouse SQL.",
+	"insight-create": {
+		"description": "Create an insight. This can be a trend / funnel / HogQL insight. Where possible, use a trend or a funnel. If you want to use a HogQL insight, you should first use the \"insight-generate-hogql-from-query\" tool to get the HogQL, and then use that HogQL query to create the insight, this is slow so you should only do it if a trend / funnel will not work. An insight requires a name, query, and other optional properties. HogQL is a custom variant of Clickhouse SQL - it does not support many normal SQL operations.",
 		"category": "Insights & analytics",
 		"summary": "Save a query as an insight.",
 		"title": "Create insight from query"
@@ -125,14 +125,14 @@
 		"summary": "Get all insights in the project with optional filtering.",
 		"title": "Get all insights"
 	},
-	"get-sql-insight": {
+	"insights-generate-hogql-from-question": {
 		"description": "Queries project's PostHog data based on a provided natural language question - don't provide SQL query as input but describe the output you want. Data warehouse schema includes data like events and persons. Fetches the result as a Server-Sent Events (SSE) stream and provides the concatenated data content. When giving the results back to the user, first show the SQL query that was used, then provide results in reasily readable format. You should also offer to save the query as an insight if the user wants to.",
 		"category": "Insights & analytics",
 		"summary": "Queries project's PostHog data based on a provided natural language question.",
-		"title": "Create SQL insight from question"
+		"title": "Generate SQL"
 	},
 	"insight-update": {
-		"description": "Update an existing insight by ID. Can update name, description, filters, and other properties.",
+		"description": "Update an existing insight by ID. Can update name, description, filters, and other properties. You should get the insight before update it to see it's current query structure, and only modify the parts needed to answer the user's request.",
 		"category": "Insights & analytics",
 		"summary": "Update an existing insight by ID.",
 		"title": "Update insight"

--- a/schema/tool-inputs.json
+++ b/schema/tool-inputs.json
@@ -525,69 +525,1394 @@
               "type": "string"
             },
             "query": {
-              "type": "object",
-              "properties": {
-                "kind": {
-                  "type": "string",
-                  "const": "DataVisualizationNode"
-                },
-                "source": {
+              "anyOf": [
+                {
                   "type": "object",
                   "properties": {
                     "kind": {
                       "type": "string",
-                      "const": "HogQLQuery"
+                      "const": "InsightVizNode"
                     },
-                    "query": {
-                      "type": "string"
-                    },
-                    "explain": {
-                      "type": "boolean"
-                    },
-                    "filters": {
-                      "type": "object",
-                      "properties": {
-                        "dateRange": {
+                    "source": {
+                      "anyOf": [
+                        {
                           "type": "object",
                           "properties": {
-                            "date_from": {
-                              "type": "string",
-                              "description": "The start date of the date range. Could be a date string or a relative date string like '-7d'"
+                            "dateRange": {
+                              "type": "object",
+                              "properties": {
+                                "date_from": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "date_to": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "explicitDate": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "additionalProperties": false
                             },
-                            "date_to": {
+                            "filterTestAccounts": {
+                              "type": "boolean",
+                              "default": false
+                            },
+                            "properties": {
+                              "anyOf": [
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "anyOf": [
+                                              {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  },
+                                                  {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "number"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "operator": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "enum": [
+                                              "AND",
+                                              "OR"
+                                            ]
+                                          },
+                                          "values": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "anyOf": [
+                                                    {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "type": "number"
+                                                        },
+                                                        {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "number"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "type": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "values"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "AND",
+                                        "OR"
+                                      ]
+                                    },
+                                    "values": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "anyOf": [
+                                              {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  },
+                                                  {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "number"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "operator": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "values"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              ],
+                              "default": []
+                            },
+                            "kind": {
                               "type": "string",
-                              "description": "The end date of the date range. Could be a date string or a relative date string like '-1d'"
+                              "const": "TrendsQuery"
+                            },
+                            "interval": {
+                              "type": "string",
+                              "enum": [
+                                "hour",
+                                "day",
+                                "week",
+                                "month"
+                              ],
+                              "default": "day"
+                            },
+                            "series": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "custom_name": {
+                                    "type": "string"
+                                  },
+                                  "math": {
+                                    "type": "string",
+                                    "enum": [
+                                      "total",
+                                      "dau",
+                                      "weekly_active",
+                                      "monthly_active",
+                                      "unique_session",
+                                      "first_time_for_user",
+                                      "first_matching_event_for_user",
+                                      "avg",
+                                      "sum",
+                                      "min",
+                                      "max",
+                                      "median",
+                                      "p75",
+                                      "p90",
+                                      "p95",
+                                      "p99"
+                                    ]
+                                  },
+                                  "math_property": {
+                                    "type": "string"
+                                  },
+                                  "properties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "anyOf": [
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "anyOf": [
+                                                    {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "type": "number"
+                                                        },
+                                                        {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "number"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "type": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "additionalProperties": false
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "AND",
+                                                    "OR"
+                                                  ]
+                                                },
+                                                "values": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "anyOf": [
+                                                          {
+                                                            "anyOf": [
+                                                              {
+                                                                "type": "string"
+                                                              },
+                                                              {
+                                                                "type": "number"
+                                                              },
+                                                              {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "number"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "operator": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  }
+                                                }
+                                              },
+                                              "required": [
+                                                "type",
+                                                "values"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "enum": [
+                                              "AND",
+                                              "OR"
+                                            ]
+                                          },
+                                          "values": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "anyOf": [
+                                                    {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "type": "number"
+                                                        },
+                                                        {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "number"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "type": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "values"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  },
+                                  "kind": {
+                                    "type": "string",
+                                    "const": "EventsNode"
+                                  },
+                                  "event": {
+                                    "type": "string"
+                                  },
+                                  "limit": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "kind"
+                                ],
+                                "additionalProperties": false
+                              }
+                            },
+                            "trendsFilter": {
+                              "type": "object",
+                              "properties": {
+                                "display": {
+                                  "type": "string",
+                                  "enum": [
+                                    "ActionsLineGraph",
+                                    "ActionsTable",
+                                    "ActionsPie",
+                                    "ActionsBar",
+                                    "ActionsBarValue",
+                                    "WorldMap",
+                                    "BoldNumber"
+                                  ],
+                                  "default": "ActionsLineGraph"
+                                },
+                                "showLegend": {
+                                  "type": "boolean",
+                                  "default": false
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "breakdownFilter": {
+                              "type": "object",
+                              "properties": {
+                                "breakdown_type": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "person",
+                                        "event"
+                                      ]
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": "event"
+                                },
+                                "breakdown_limit": {
+                                  "type": "number"
+                                },
+                                "breakdown": {
+                                  "anyOf": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": [
+                                              "string",
+                                              "number"
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "compareFilter": {
+                              "type": "object",
+                              "properties": {
+                                "compare": {
+                                  "type": "boolean",
+                                  "default": false
+                                },
+                                "compare_to": {
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "conversionGoal": {
+                              "anyOf": [
+                                {},
+                                {
+                                  "type": "null"
+                                }
+                              ]
                             }
                           },
                           "required": [
-                            "date_from",
-                            "date_to"
+                            "kind",
+                            "series"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "dateRange": {
+                              "type": "object",
+                              "properties": {
+                                "date_from": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "date_to": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "explicitDate": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "filterTestAccounts": {
+                              "type": "boolean",
+                              "default": false
+                            },
+                            "properties": {
+                              "anyOf": [
+                                {
+                                  "type": "array",
+                                  "items": {
+                                    "anyOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "anyOf": [
+                                              {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  },
+                                                  {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "number"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "operator": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "enum": [
+                                              "AND",
+                                              "OR"
+                                            ]
+                                          },
+                                          "values": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "anyOf": [
+                                                    {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "type": "number"
+                                                        },
+                                                        {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "number"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "type": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "values"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "AND",
+                                        "OR"
+                                      ]
+                                    },
+                                    "values": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "value": {
+                                            "anyOf": [
+                                              {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  },
+                                                  {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "number"
+                                                    }
+                                                  }
+                                                ]
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "operator": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "values"
+                                  ],
+                                  "additionalProperties": false
+                                }
+                              ],
+                              "default": []
+                            },
+                            "kind": {
+                              "type": "string",
+                              "const": "FunnelsQuery"
+                            },
+                            "interval": {
+                              "type": "string",
+                              "enum": [
+                                "hour",
+                                "day",
+                                "week",
+                                "month"
+                              ]
+                            },
+                            "series": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "custom_name": {
+                                    "type": "string"
+                                  },
+                                  "math": {
+                                    "type": "string",
+                                    "enum": [
+                                      "total",
+                                      "dau",
+                                      "weekly_active",
+                                      "monthly_active",
+                                      "unique_session",
+                                      "first_time_for_user",
+                                      "first_matching_event_for_user",
+                                      "avg",
+                                      "sum",
+                                      "min",
+                                      "max",
+                                      "median",
+                                      "p75",
+                                      "p90",
+                                      "p95",
+                                      "p99"
+                                    ]
+                                  },
+                                  "math_property": {
+                                    "type": "string"
+                                  },
+                                  "properties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "anyOf": [
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "anyOf": [
+                                                    {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "type": "number"
+                                                        },
+                                                        {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "number"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "type": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "additionalProperties": false
+                                            },
+                                            {
+                                              "type": "object",
+                                              "properties": {
+                                                "type": {
+                                                  "type": "string",
+                                                  "enum": [
+                                                    "AND",
+                                                    "OR"
+                                                  ]
+                                                },
+                                                "values": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "value": {
+                                                        "anyOf": [
+                                                          {
+                                                            "anyOf": [
+                                                              {
+                                                                "type": "string"
+                                                              },
+                                                              {
+                                                                "type": "number"
+                                                              },
+                                                              {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "type": "number"
+                                                                }
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "operator": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "key"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  }
+                                                }
+                                              },
+                                              "required": [
+                                                "type",
+                                                "values"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "enum": [
+                                              "AND",
+                                              "OR"
+                                            ]
+                                          },
+                                          "values": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "anyOf": [
+                                                    {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "type": "number"
+                                                        },
+                                                        {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "number"
+                                                          }
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "type": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "required": [
+                                                "key"
+                                              ],
+                                              "additionalProperties": false
+                                            }
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "values"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  },
+                                  "kind": {
+                                    "type": "string",
+                                    "const": "EventsNode"
+                                  },
+                                  "event": {
+                                    "type": "string"
+                                  },
+                                  "limit": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "kind"
+                                ],
+                                "additionalProperties": false
+                              },
+                              "minItems": 2
+                            },
+                            "funnelsFilter": {
+                              "type": "object",
+                              "properties": {
+                                "layout": {
+                                  "type": "string",
+                                  "enum": [
+                                    "horizontal",
+                                    "vertical"
+                                  ],
+                                  "default": "vertical"
+                                },
+                                "breakdownAttributionType": {
+                                  "type": "string",
+                                  "enum": [
+                                    "first_touch",
+                                    "last_touch",
+                                    "all_events"
+                                  ],
+                                  "default": "first_touch"
+                                },
+                                "breakdownAttributionValue": {
+                                  "type": "number"
+                                },
+                                "funnelToStep": {
+                                  "type": "number"
+                                },
+                                "funnelFromStep": {
+                                  "type": "number"
+                                },
+                                "funnelOrderType": {
+                                  "type": "string",
+                                  "enum": [
+                                    "ordered",
+                                    "unordered",
+                                    "strict"
+                                  ],
+                                  "default": "ordered"
+                                },
+                                "funnelVizType": {
+                                  "type": "string",
+                                  "enum": [
+                                    "steps",
+                                    "time_to_convert",
+                                    "trends"
+                                  ],
+                                  "default": "steps"
+                                },
+                                "funnelWindowInterval": {
+                                  "type": "number",
+                                  "default": 14
+                                },
+                                "funnelWindowIntervalUnit": {
+                                  "type": "string",
+                                  "enum": [
+                                    "minute",
+                                    "hour",
+                                    "day",
+                                    "week",
+                                    "month"
+                                  ],
+                                  "default": "day"
+                                },
+                                "funnelStepReference": {
+                                  "type": "string",
+                                  "enum": [
+                                    "total",
+                                    "previous"
+                                  ],
+                                  "default": "total"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "breakdownFilter": {
+                              "type": "object",
+                              "properties": {
+                                "breakdown_type": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string",
+                                      "enum": [
+                                        "person",
+                                        "event"
+                                      ]
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ],
+                                  "default": "event"
+                                },
+                                "breakdown_limit": {
+                                  "type": "number"
+                                },
+                                "breakdown": {
+                                  "anyOf": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "array",
+                                          "items": {
+                                            "type": [
+                                              "string",
+                                              "number"
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "series"
                           ],
                           "additionalProperties": false
                         }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "kind",
+                    "source"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "kind": {
+                      "type": "string",
+                      "const": "DataVisualizationNode"
+                    },
+                    "source": {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "const": "HogQLQuery"
+                        },
+                        "query": {
+                          "type": "string"
+                        },
+                        "filters": {
+                          "type": "object",
+                          "properties": {
+                            "properties": {
+                              "type": "array",
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "anyOf": [
+                                          {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "number"
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "operator": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "type": {
+                                        "type": "string",
+                                        "enum": [
+                                          "AND",
+                                          "OR"
+                                        ]
+                                      },
+                                      "values": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "anyOf": [
+                                                {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "number"
+                                                    },
+                                                    {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "number"
+                                                      }
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "type": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "required": [
+                                            "key"
+                                          ],
+                                          "additionalProperties": false
+                                        }
+                                      }
+                                    },
+                                    "required": [
+                                      "type",
+                                      "values"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                ]
+                              }
+                            },
+                            "dateRange": {
+                              "type": "object",
+                              "properties": {
+                                "date_from": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "date_to": {
+                                  "type": [
+                                    "string",
+                                    "null"
+                                  ]
+                                },
+                                "explicitDate": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "filterTestAccounts": {
+                              "type": "boolean"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
                       },
+                      "required": [
+                        "kind",
+                        "query"
+                      ],
                       "additionalProperties": false
                     }
                   },
                   "required": [
                     "kind",
-                    "query"
+                    "source"
                   ],
                   "additionalProperties": false
                 }
-              },
-              "required": [
-                "kind",
-                "source"
-              ],
-              "additionalProperties": false
+              ]
             },
             "description": {
               "type": "string"
-            },
-            "saved": {
-              "type": "boolean",
-              "default": true
             },
             "favorited": {
               "type": "boolean",
@@ -624,6 +1949,20 @@
       ],
       "additionalProperties": false
     },
+    "InsightGenerateHogQLFromQuestionSchema": {
+      "type": "object",
+      "properties": {
+        "question": {
+          "type": "string",
+          "maxLength": 1000,
+          "description": "Your natural language query describing the SQL insight (max 1000 characters)."
+        }
+      },
+      "required": [
+        "question"
+      ],
+      "additionalProperties": false
+    },
     "InsightGetAllSchema": {
       "type": "object",
       "properties": {
@@ -635,9 +1974,6 @@
             },
             "offset": {
               "type": "number"
-            },
-            "saved": {
-              "type": "boolean"
             },
             "favorited": {
               "type": "boolean"
@@ -660,20 +1996,6 @@
       },
       "required": [
         "insightId"
-      ],
-      "additionalProperties": false
-    },
-    "InsightGetSqlSchema": {
-      "type": "object",
-      "properties": {
-        "query": {
-          "type": "string",
-          "maxLength": 1000,
-          "description": "Your natural language query describing the SQL insight (max 1000 characters)."
-        }
-      },
-      "required": [
-        "query"
       ],
       "additionalProperties": false
     },
@@ -711,9 +2033,6 @@
             "query": {
               "type": "object",
               "additionalProperties": {}
-            },
-            "saved": {
-              "type": "boolean"
             },
             "favorited": {
               "type": "boolean"

--- a/typescript/src/api/client.ts
+++ b/typescript/src/api/client.ts
@@ -23,6 +23,8 @@ import {
 	CreateInsightInputSchema,
 	type ListInsightsData,
 	ListInsightsSchema,
+	type SimpleInsight,
+	SimpleInsightSchema,
 } from "@/schema/insights";
 import { type Organization, OrganizationSchema } from "@/schema/orgs";
 import { type Project, ProjectSchema } from "@/schema/projects";
@@ -382,16 +384,7 @@ export class ApiClient {
 		return {
 			list: async ({
 				params,
-			}: { params?: ListInsightsData } = {}): Promise<
-				Result<
-					Array<{
-						id: number;
-						name?: string | null | undefined;
-						short_id: string;
-						description?: string | null | undefined;
-					}>
-				>
-			> => {
+			}: { params?: ListInsightsData } = {}): Promise<Result<Array<SimpleInsight>>> => {
 				const validatedParams = params ? ListInsightsSchema.parse(params) : undefined;
 				const searchParams = new URLSearchParams();
 
@@ -405,15 +398,8 @@ export class ApiClient {
 
 				const url = `${this.baseUrl}/api/projects/${projectId}/insights/${searchParams.toString() ? `?${searchParams}` : ""}`;
 
-				const simpleInsightSchema = z.object({
-					id: z.number(),
-					name: z.string().nullish(),
-					short_id: z.string(),
-					description: z.string().nullish(),
-				});
-
 				const responseSchema = z.object({
-					results: z.array(simpleInsightSchema),
+					results: z.array(SimpleInsightSchema),
 				});
 
 				const result = await this.fetchWithSchema(url, responseSchema);
@@ -425,20 +411,12 @@ export class ApiClient {
 
 			create: async ({
 				data,
-			}: { data: CreateInsightInput }): Promise<
-				Result<{ id: number; name: string; short_id: string }>
-			> => {
+			}: { data: CreateInsightInput }): Promise<Result<SimpleInsight>> => {
 				const validatedInput = CreateInsightInputSchema.parse(data);
-
-				const createResponseSchema = z.object({
-					id: z.number(),
-					name: z.string(),
-					short_id: z.string(),
-				});
 
 				return this.fetchWithSchema(
 					`${this.baseUrl}/api/projects/${projectId}/insights/`,
-					createResponseSchema,
+					SimpleInsightSchema,
 					{
 						method: "POST",
 						body: JSON.stringify(validatedInput),
@@ -450,25 +428,7 @@ export class ApiClient {
 				insightId,
 			}: {
 				insightId: string;
-			}): Promise<
-				Result<{
-					id: number;
-					name?: string | null | undefined;
-					short_id: string;
-					description?: string | null | undefined;
-					query?: any;
-					filters?: any;
-				}>
-			> => {
-				const simpleInsightSchema = z.object({
-					id: z.number(),
-					name: z.string().nullish(),
-					short_id: z.string(),
-					description: z.string().nullish(),
-					query: z.any(),
-					filters: z.any(),
-				});
-
+			}): Promise<Result<SimpleInsight>> => {
 				// Check if insightId is a short_id (8 character alphanumeric string)
 				// Note: This won't work when we start creating insight id's with 8 digits. (We're at 7 currently)
 				if (isShortId(insightId)) {
@@ -476,7 +436,7 @@ export class ApiClient {
 					const url = `${this.baseUrl}/api/projects/${projectId}/insights/?${searchParams}`;
 
 					const responseSchema = z.object({
-						results: z.array(simpleInsightSchema),
+						results: z.array(SimpleInsightSchema),
 					});
 
 					const result = await this.fetchWithSchema(url, responseSchema);
@@ -500,21 +460,21 @@ export class ApiClient {
 
 				return this.fetchWithSchema(
 					`${this.baseUrl}/api/projects/${projectId}/insights/${insightId}/`,
-					simpleInsightSchema,
+					SimpleInsightSchema,
 				);
 			},
 
 			update: async ({
 				insightId,
 				data,
-			}: { insightId: number; data: any }): Promise<
-				Result<{ id: number; name: string; short_id: string }>
-			> => {
-				const updateResponseSchema = z.object({
-					id: z.number(),
-					name: z.string(),
-					short_id: z.string(),
-				});
+			}: { insightId: number; data: any }): Promise<Result<SimpleInsight>> => {
+				const updateResponseSchema = z
+					.object({
+						id: z.number(),
+						name: z.string(),
+						short_id: z.string(),
+					})
+					.passthrough();
 
 				return this.fetchWithSchema(
 					`${this.baseUrl}/api/projects/${projectId}/insights/${insightId}/`,

--- a/typescript/src/api/client.ts
+++ b/typescript/src/api/client.ts
@@ -67,10 +67,10 @@ export class ApiClient {
 		options?: RequestInit,
 	): Promise<Result<T>> {
 		try {
-			if (options?.method === 'POST' || options?.method === 'PATCH') {
+			if (options?.method === "POST" || options?.method === "PATCH") {
 				console.log(`[API Request] ${options.method} ${url}, Body: ${options.body}`);
 			}
-			
+
 			const response = await fetch(url, {
 				...options,
 				headers: {
@@ -85,15 +85,17 @@ export class ApiClient {
 				}
 
 				const errorText = await response.text();
-				console.log(`[API Error] Status: ${response.status}, URL: ${url}, Response: ${errorText}`);
-				
+				console.log(
+					`[API Error] Status: ${response.status}, URL: ${url}, Response: ${errorText}`,
+				);
+
 				let errorData: any;
 				try {
 					errorData = JSON.parse(errorText);
 				} catch {
 					errorData = { detail: errorText };
 				}
-				
+
 				if (errorData.type === "validation_error" && errorData.code) {
 					throw new Error(`Validation error: ${errorData.code}`);
 				}

--- a/typescript/src/integrations/mcp/index.ts
+++ b/typescript/src/integrations/mcp/index.ts
@@ -15,7 +15,7 @@ import type { CloudRegion, Context, State, Tool } from "@/tools/types";
 
 const INSTRUCTIONS = `
 - You are a helpful assistant that can query PostHog API.
-- If some resource from another tool is not found, ask the user if they want to try finding it in another project.
+- If you get errors due to permissions being denied, check that you have the correct active project and that the user has access to the required project.
 - If you cannot answer the user's PostHog related request or question using other available tools in this MCP, use the 'docs-search' tool to provide information from the documentation to guide user how they can do it themselves - when doing so provide condensed instructions with links to sources.
 `;
 
@@ -27,7 +27,7 @@ type RequestProperties = {
 // Define our MCP agent with tools
 export class MyMCP extends McpAgent<Env> {
 	server = new McpServer({
-		name: "PostHog MCP",
+		name: "PostHog",
 		version: "1.0.0",
 		instructions: INSTRUCTIONS,
 	});

--- a/typescript/src/lib/analytics.ts
+++ b/typescript/src/lib/analytics.ts
@@ -1,0 +1,1 @@
+export type AnalyticsEvent = "mcp tool call";

--- a/typescript/src/schema/dashboards.ts
+++ b/typescript/src/schema/dashboards.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { QuerySchema } from "./query";
 
 export const DashboardTileSchema = z.object({
 	insight: z.object({
@@ -7,7 +6,7 @@ export const DashboardTileSchema = z.object({
 		name: z.string(),
 		derived_name: z.string().nullable(),
 		description: z.string().nullable(),
-		query: QuerySchema,
+		query: z.any(),
 		created_at: z.string().nullish(),
 		updated_at: z.string().nullish(),
 		favorited: z.boolean().nullish(),

--- a/typescript/src/schema/dashboards.ts
+++ b/typescript/src/schema/dashboards.ts
@@ -10,7 +10,6 @@ export const DashboardTileSchema = z.object({
 		created_at: z.string().nullish(),
 		updated_at: z.string().nullish(),
 		favorited: z.boolean().nullish(),
-		saved: z.boolean().nullish(),
 		tags: z.array(z.string()).nullish(),
 	}),
 	order: z.number(),

--- a/typescript/src/schema/errors.ts
+++ b/typescript/src/schema/errors.ts
@@ -26,9 +26,7 @@ export const ListErrorsSchema = z.object({
 	dateTo: z.string().datetime().optional(),
 	orderDirection: z.nativeEnum(OrderDirectionErrors).optional(),
 	filterTestAccounts: z.boolean().optional(),
-	// limit: z.number().optional(),
 	status: z.nativeEnum(StatusErrors).optional(),
-	// TODO: assigned to
 });
 
 export const ErrorDetailsSchema = z.object({

--- a/typescript/src/schema/insights.ts
+++ b/typescript/src/schema/insights.ts
@@ -21,7 +21,6 @@ export const InsightSchema = z.object({
 		})
 		.optional()
 		.nullable(),
-	saved: z.boolean(),
 	favorited: z.boolean().nullish(),
 	deleted: z.boolean(),
 	dashboard: z.number().nullish(),
@@ -48,7 +47,6 @@ export const CreateInsightInputSchema = z.object({
 	name: z.string(),
 	query: InsightQuerySchema,
 	description: z.string().optional(),
-	saved: z.boolean().default(true),
 	favorited: z.boolean().default(false),
 	tags: z.array(z.string()).optional(),
 });
@@ -58,7 +56,6 @@ export const UpdateInsightInputSchema = z.object({
 	description: z.string().optional(),
 	filters: z.record(z.any()).optional(),
 	query: z.record(z.any()).optional(),
-	saved: z.boolean().optional(),
 	favorited: z.boolean().optional(),
 	dashboard: z.number().optional(),
 	tags: z.array(z.string()).optional(),
@@ -67,7 +64,6 @@ export const UpdateInsightInputSchema = z.object({
 export const ListInsightsSchema = z.object({
 	limit: z.number().optional(),
 	offset: z.number().optional(),
-	saved: z.boolean().optional(),
 	favorited: z.boolean().optional(),
 	search: z.string().optional(),
 });

--- a/typescript/src/schema/insights.ts
+++ b/typescript/src/schema/insights.ts
@@ -3,10 +3,11 @@ import { InsightQuerySchema } from "./query";
 
 export const InsightSchema = z.object({
 	id: z.number(),
+	short_id: z.string(),
 	name: z.string().nullish(),
 	description: z.string().nullish(),
 	filters: z.record(z.any()),
-	query: z.record(z.any()).nullish(),
+	query: z.any().nullish(),
 	result: z.any().optional(),
 	created_at: z.string(),
 	updated_at: z.string(),
@@ -29,6 +30,18 @@ export const InsightSchema = z.object({
 	last_refresh: z.string().nullish(),
 	refreshing: z.boolean().nullish(),
 	tags: z.array(z.string()).nullish(),
+});
+
+export const SimpleInsightSchema = InsightSchema.pick({
+	id: true,
+	name: true,
+	short_id: true,
+	description: true,
+	filters: true,
+	query: true,
+	created_at: true,
+	updated_at: true,
+	favorited: true,
 });
 
 export const CreateInsightInputSchema = z.object({
@@ -63,6 +76,7 @@ export type PostHogInsight = z.infer<typeof InsightSchema>;
 export type CreateInsightInput = z.infer<typeof CreateInsightInputSchema>;
 export type UpdateInsightInput = z.infer<typeof UpdateInsightInputSchema>;
 export type ListInsightsData = z.infer<typeof ListInsightsSchema>;
+export type SimpleInsight = z.infer<typeof SimpleInsightSchema>;
 
 export const SQLInsightResponseSchema = z.array(
 	z.object({

--- a/typescript/src/schema/query.ts
+++ b/typescript/src/schema/query.ts
@@ -89,11 +89,9 @@ const PROPERTY_MATH_TYPES = ["avg", "sum", "min", "max", "median", "p75", "p90",
 
 // Base entity object without refinement for extension
 const BaseEntityObject = z.object({
-	// id: z.union([z.string(), z.number()]), TODO: what to do with updates and ids?
-	custom_name: z.string().optional(),
+	custom_name: z.string().describe("A display name"),
 	math: MathType.optional(),
 	math_property: z.string().optional(),
-	// order: z.number().optional(), this is getting used in funnels incorrectly
 	properties: z.union([z.array(AnyPropertyFilter), PropertyGroupFilter]).optional(),
 });
 

--- a/typescript/src/schema/query.ts
+++ b/typescript/src/schema/query.ts
@@ -71,10 +71,9 @@ const HogQLFilters = z.object({
 // Entity nodes
 const BaseEntityNode = z.object({
 	// id: z.union([z.string(), z.number()]), TODO: what to do with updates and ids?
-	name: z.string().optional(),
 	custom_name: z.string().optional(),
 	math: z.enum(["total"]).optional(),
-	order: z.number().optional(),
+	// order: z.number().optional(), this is getting used in funnels incorrectly
 	properties: z.union([z.array(AnyPropertyFilter), PropertyGroupFilter]).optional(),
 });
 

--- a/typescript/src/schema/query.ts
+++ b/typescript/src/schema/query.ts
@@ -70,9 +70,10 @@ const HogQLFilters = z.object({
 
 // Entity nodes
 const BaseEntityNode = z.object({
-	id: z.union([z.string(), z.number()]),
+	// id: z.union([z.string(), z.number()]), TODO: what to do with updates and ids?
 	name: z.string().optional(),
 	custom_name: z.string().optional(),
+	math: z.enum(["total"]).optional(),
 	order: z.number().optional(),
 	properties: z.union([z.array(AnyPropertyFilter), PropertyGroupFilter]).optional(),
 });
@@ -134,7 +135,6 @@ const HogQLQuerySchema = z.object({
 	kind: z.literal("HogQLQuery"),
 	query: z.string(),
 	filters: HogQLFilters.optional(),
-	explain: z.boolean().optional(),
 });
 
 // Funnels filter
@@ -160,12 +160,21 @@ const FunnelsQuerySchema = InsightsQueryBase.extend({
 	breakdownFilter: BreakdownFilter.optional(),
 });
 
-// Any insight query
+// Insight Schema
+const InsightVizNodeSchema = z.object({
+	kind: z.literal("InsightVizNode"),
+	source: z.discriminatedUnion("kind", [TrendsQuerySchema, FunnelsQuerySchema]),
+});
 
+const DataVisualizationNodeSchema = z.object({
+	kind: z.literal("DataVisualizationNode"),
+	source: HogQLQuerySchema,
+});
+
+// Any insight query
 const InsightQuerySchema = z.discriminatedUnion("kind", [
-	TrendsQuerySchema,
-	FunnelsQuerySchema,
-	HogQLQuerySchema,
+	InsightVizNodeSchema,
+	DataVisualizationNodeSchema,
 ]);
 
 // Export all schemas
@@ -201,6 +210,8 @@ export {
 	TrendsQuerySchema,
 	FunnelsQuerySchema,
 	HogQLQuerySchema,
+	InsightVizNodeSchema,
+	DataVisualizationNodeSchema,
 	InsightQuerySchema,
 };
 

--- a/typescript/src/schema/query.ts
+++ b/typescript/src/schema/query.ts
@@ -1,37 +1,210 @@
 import { z } from "zod";
 
-export const DateRangeSchema = z.object({
-	date_from: z
-		.string()
-		.describe(
-			"The start date of the date range. Could be a date string or a relative date string like '-7d'",
-		),
-	date_to: z
-		.string()
-		.describe(
-			"The end date of the date range. Could be a date string or a relative date string like '-1d'",
-		),
+// Common enums and types
+const NodeKind = z.enum(["TrendsQuery", "FunnelsQuery", "HogQLQuery", "EventsNode"]);
+
+const IntervalType = z.enum(["hour", "day", "week", "month"]);
+
+const ChartDisplayType = z.enum([
+	"ActionsLineGraph",
+	"ActionsTable",
+	"ActionsPie",
+	"ActionsBar",
+	"ActionsBarValue",
+	"WorldMap",
+	"BoldNumber",
+]);
+
+// NOTE: Breakdowns are restricted to either person or event for simplicity
+const BreakdownType = z.enum(["person", "event"]);
+
+const FunnelVizType = z.enum(["steps", "time_to_convert", "trends"]);
+
+const FunnelOrderType = z.enum(["ordered", "unordered", "strict"]);
+
+const FunnelStepReference = z.enum(["total", "previous"]);
+
+const BreakdownAttributionType = z.enum(["first_touch", "last_touch", "all_events"]);
+
+const FunnelLayout = z.enum(["horizontal", "vertical"]);
+
+const FunnelConversionWindowTimeUnit = z.enum(["minute", "hour", "day", "week", "month"]);
+
+// Base schemas
+const DateRange = z.object({
+	date_from: z.string().nullable().optional(),
+	date_to: z.string().nullable().optional(),
+	explicitDate: z.boolean().optional(),
 });
 
-export const HogQLFiltersSchema = z.object({
-	dateRange: DateRangeSchema.optional(),
+const PropertyFilter = z.object({
+	key: z.string(),
+	value: z
+		.union([z.string(), z.number(), z.array(z.string()), z.array(z.number())])
+		.nullable()
+		.optional(),
+	operator: z.string().optional(),
+	type: z.string().optional(),
 });
 
-export const HogQLQuerySchema = z.object({
+// NOTE: Only a single level of nesting is supported here, since we can't specify recursive schema for tool inputs.
+const PropertyGroupFilter = z.object({
+	type: z.enum(["AND", "OR"]),
+	values: z.array(PropertyFilter),
+});
+
+const AnyPropertyFilter = z.union([PropertyFilter, PropertyGroupFilter]);
+
+const HogQLVariable = z.object({
+	variableId: z.string(),
+	code_name: z.string(),
+	value: z.any().optional(),
+	isNull: z.boolean().optional(),
+});
+
+const HogQLFilters = z.object({
+	properties: z.array(AnyPropertyFilter).optional(),
+	dateRange: DateRange.optional(),
+	filterTestAccounts: z.boolean().optional(),
+});
+
+// Entity nodes
+const BaseEntityNode = z.object({
+	id: z.union([z.string(), z.number()]),
+	name: z.string().optional(),
+	custom_name: z.string().optional(),
+	order: z.number().optional(),
+	properties: z.union([z.array(AnyPropertyFilter), PropertyGroupFilter]).optional(),
+});
+
+const EventsNode = BaseEntityNode.extend({
+	kind: z.literal("EventsNode"),
+	event: z.string().optional(),
+	limit: z.number().optional(),
+});
+
+const AnyEntityNode = EventsNode;
+
+// Base query interface
+const InsightsQueryBase = z.object({
+	dateRange: DateRange.optional(),
+	filterTestAccounts: z.boolean().optional().default(false),
+	properties: z
+		.union([z.array(AnyPropertyFilter), PropertyGroupFilter])
+		.optional()
+		.default([]),
+	aggregation_group_type_index: z.number().nullable().optional(),
+});
+
+// Breakdown filter
+const BreakdownFilter = z.object({
+	breakdown_type: BreakdownType.nullable().optional().default("event"),
+	breakdown_limit: z.number().optional(),
+	breakdown: z
+		.union([z.string(), z.number(), z.array(z.union([z.string(), z.number()]))])
+		.nullable()
+		.optional(),
+});
+
+// Compare filter
+const CompareFilter = z.object({
+	compare: z.boolean().optional().default(false),
+	compare_to: z.string().optional(),
+});
+
+// Trends filter
+const TrendsFilter = z.object({
+	display: ChartDisplayType.optional().default("ActionsLineGraph"),
+	showLegend: z.boolean().optional().default(false),
+});
+
+// Trends query
+const TrendsQuerySchema = InsightsQueryBase.extend({
+	kind: z.literal("TrendsQuery"),
+	interval: IntervalType.optional().default("day"),
+	series: z.array(AnyEntityNode),
+	trendsFilter: TrendsFilter.optional(),
+	breakdownFilter: BreakdownFilter.optional(),
+	compareFilter: CompareFilter.optional(),
+	conversionGoal: z.any().nullable().optional(),
+});
+
+// HogQL query
+const HogQLQuerySchema = z.object({
 	kind: z.literal("HogQLQuery"),
 	query: z.string(),
+	filters: HogQLFilters.optional(),
 	explain: z.boolean().optional(),
-	filters: HogQLFiltersSchema.optional(),
 });
 
-export const InsightQuerySchema = z.object({
-	kind: z.literal("DataVisualizationNode"),
-	source: HogQLQuerySchema,
+// Funnels filter
+const FunnelsFilter = z.object({
+	layout: FunnelLayout.optional().default("vertical"),
+	breakdownAttributionType: BreakdownAttributionType.optional().default("first_touch"),
+	breakdownAttributionValue: z.number().optional(),
+	funnelToStep: z.number().optional(),
+	funnelFromStep: z.number().optional(),
+	funnelOrderType: FunnelOrderType.optional().default("ordered"),
+	funnelVizType: FunnelVizType.optional().default("steps"),
+	funnelWindowInterval: z.number().optional().default(14),
+	funnelWindowIntervalUnit: FunnelConversionWindowTimeUnit.optional().default("day"),
+	funnelStepReference: FunnelStepReference.optional().default("total"),
 });
 
-export const QuerySchema = z.any();
+// Funnels query
+const FunnelsQuerySchema = InsightsQueryBase.extend({
+	kind: z.literal("FunnelsQuery"),
+	interval: IntervalType.optional(),
+	series: z.array(AnyEntityNode),
+	funnelsFilter: FunnelsFilter.optional(),
+	breakdownFilter: BreakdownFilter.optional(),
+});
 
-export type InsightQuery = z.infer<typeof InsightQuerySchema>;
+// Any insight query
+
+const InsightQuerySchema = z.discriminatedUnion("kind", [
+	TrendsQuerySchema,
+	FunnelsQuerySchema,
+	HogQLQuerySchema,
+]);
+
+// Export all schemas
+export {
+	// Enums
+	NodeKind,
+	IntervalType,
+	ChartDisplayType,
+	BreakdownType,
+	FunnelVizType,
+	FunnelOrderType,
+	FunnelStepReference,
+	BreakdownAttributionType,
+	FunnelLayout,
+	FunnelConversionWindowTimeUnit,
+	// Base types
+	DateRange,
+	PropertyFilter,
+	PropertyGroupFilter,
+	AnyPropertyFilter,
+	// Entity nodes
+	EventsNode,
+	AnyEntityNode,
+	// Filters
+	BreakdownFilter,
+	CompareFilter,
+	TrendsFilter,
+	FunnelsFilter,
+	// HogQL types
+	HogQLVariable,
+	HogQLFilters,
+	// Queries
+	TrendsQuerySchema,
+	FunnelsQuerySchema,
+	HogQLQuerySchema,
+	InsightQuerySchema,
+};
+
+export type TrendsQuery = z.infer<typeof TrendsQuerySchema>;
+export type FunnelsQuery = z.infer<typeof FunnelsQuerySchema>;
 export type HogQLQuery = z.infer<typeof HogQLQuerySchema>;
-export type HogQLFilters = z.infer<typeof HogQLFiltersSchema>;
-export type DateRange = z.infer<typeof DateRangeSchema>;
+export type InsightQuery = z.infer<typeof InsightQuerySchema>;

--- a/typescript/src/schema/tool-inputs.ts
+++ b/typescript/src/schema/tool-inputs.ts
@@ -89,8 +89,8 @@ export const InsightGetAllSchema = z.object({
 	data: ListInsightsSchema.optional(),
 });
 
-export const InsightGetSqlSchema = z.object({
-	query: z
+export const InsightGenerateHogQLFromQuestionSchema = z.object({
+	question: z
 		.string()
 		.max(1000)
 		.describe("Your natural language query describing the SQL insight (max 1000 characters)."),

--- a/typescript/src/tools/index.ts
+++ b/typescript/src/tools/index.ts
@@ -29,16 +29,16 @@ import errorDetails from "./errorTracking/errorDetails";
 // Error Tracking
 import listErrors from "./errorTracking/listErrors";
 
+import getExperiment from "./experiments/get";
 // Experiments
 import getAllExperiments from "./experiments/getAll";
-import getExperiment from "./experiments/get";
 
 import createInsight from "./insights/create";
 import deleteInsight from "./insights/delete";
+import generateHogQLFromQuestion from "./insights/generateHogQLFromQuestion";
 import getInsight from "./insights/get";
 // Insights
 import getAllInsights from "./insights/getAll";
-import getSqlInsight from "./insights/getSqlInsight";
 import queryInsight from "./insights/query";
 import updateInsight from "./insights/update";
 
@@ -91,7 +91,7 @@ export const getToolsFromContext = (context: Context): Tool<ZodObjectAny>[] => [
 	updateInsight(),
 	deleteInsight(),
 	queryInsight(),
-	getSqlInsight(),
+	generateHogQLFromQuestion(),
 
 	// Dashboards
 	getAllDashboards(),

--- a/typescript/src/tools/insights/create.ts
+++ b/typescript/src/tools/insights/create.ts
@@ -23,10 +23,10 @@ export const createHandler = async (context: Context, params: Params) => {
 	return { content: [{ type: "text", text: JSON.stringify(insightWithUrl) }] };
 };
 
-const definition = getToolDefinition("insight-create-from-query");
+const definition = getToolDefinition("insight-create");
 
 const tool = (): Tool<typeof schema> => ({
-	name: "insight-create-from-query",
+	name: "insight-create",
 	title: definition.title,
 	description: definition.description,
 	schema,

--- a/typescript/src/tools/insights/generateHogQLFromQuestion.ts
+++ b/typescript/src/tools/insights/generateHogQLFromQuestion.ts
@@ -1,17 +1,17 @@
-import { InsightGetSqlSchema } from "@/schema/tool-inputs";
+import { InsightGenerateHogQLFromQuestionSchema } from "@/schema/tool-inputs";
 import { getToolDefinition } from "@/tools/toolDefinitions";
 import type { Context, Tool } from "@/tools/types";
 import type { z } from "zod";
 
-const schema = InsightGetSqlSchema;
+const schema = InsightGenerateHogQLFromQuestionSchema;
 
 type Params = z.infer<typeof schema>;
 
-export const getSqlInsightHandler = async (context: Context, params: Params) => {
-	const { query } = params;
+export const generateHogQLHandler = async (context: Context, params: Params) => {
+	const { question } = params;
 	const projectId = await context.stateManager.getProjectId();
 
-	const result = await context.api.insights({ projectId }).sqlInsight({ query });
+	const result = await context.api.insights({ projectId }).sqlInsight({ query: question });
 
 	if (!result.success) {
 		throw new Error(`Failed to execute SQL insight: ${result.error.message}`);
@@ -30,14 +30,14 @@ export const getSqlInsightHandler = async (context: Context, params: Params) => 
 	return { content: [{ type: "text", text: JSON.stringify(result.data) }] };
 };
 
-const definition = getToolDefinition("get-sql-insight");
+const definition = getToolDefinition("insights-generate-hogql-from-question");
 
 const tool = (): Tool<typeof schema> => ({
-	name: "get-sql-insight",
+	name: "insights-generate-hogql-from-question",
 	title: definition.title,
 	description: definition.description,
 	schema,
-	handler: getSqlInsightHandler,
+	handler: generateHogQLHandler,
 	annotations: {
 		destructiveHint: false,
 		idempotentHint: false,

--- a/typescript/src/tools/insights/update.ts
+++ b/typescript/src/tools/insights/update.ts
@@ -1,8 +1,8 @@
 import { InsightUpdateSchema } from "@/schema/tool-inputs";
 import { getToolDefinition } from "@/tools/toolDefinitions";
 import type { Context, Tool } from "@/tools/types";
-import { resolveInsightId } from "./utils";
 import type { z } from "zod";
+import { resolveInsightId } from "./utils";
 
 const schema = InsightUpdateSchema;
 
@@ -13,6 +13,7 @@ export const updateHandler = async (context: Context, params: Params) => {
 	const projectId = await context.stateManager.getProjectId();
 
 	const numericId = await resolveInsightId(context, insightId, projectId);
+
 	const insightResult = await context.api.insights({ projectId }).update({
 		insightId: numericId,
 		data,

--- a/typescript/tests/api/client.integration.test.ts
+++ b/typescript/tests/api/client.integration.test.ts
@@ -377,7 +377,6 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 							},
 						},
 					},
-					saved: true,
 					favorited: false,
 				},
 			});
@@ -440,7 +439,6 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 							interval: "day",
 						},
 					},
-					saved: true,
 					favorited: false,
 				};
 
@@ -496,7 +494,6 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 							},
 						},
 						favorited: false,
-						saved: true,
 					};
 
 					const result = await client.insights({ projectId: testProjectId }).create({
@@ -546,7 +543,6 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 							},
 						},
 						favorited: false,
-						saved: true,
 					};
 
 					const result = await client.insights({ projectId: testProjectId }).create({
@@ -594,7 +590,6 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 							},
 						},
 						favorited: false,
-						saved: true,
 					};
 
 					const result = await client.insights({ projectId: testProjectId }).create({
@@ -639,7 +634,6 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 						},
 					},
 					favorited: false,
-					saved: true,
 				};
 
 				const result = await client.insights({ projectId: testProjectId }).create({
@@ -694,7 +688,6 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 						},
 					},
 					favorited: false,
-					saved: true,
 				};
 
 				const result = await client.insights({ projectId: testProjectId }).create({
@@ -740,7 +733,6 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 						},
 					},
 					favorited: false,
-					saved: true,
 				};
 
 				const result = await client.insights({ projectId: testProjectId }).create({
@@ -797,7 +789,6 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 							},
 						},
 						favorited: false,
-						saved: true,
 					};
 
 					const result = await client.insights({ projectId: testProjectId }).create({
@@ -853,7 +844,6 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 							},
 						},
 						favorited: false,
-						saved: true,
 					};
 
 					const result = await client.insights({ projectId: testProjectId }).create({
@@ -906,7 +896,6 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 							},
 						},
 						favorited: false,
-						saved: true,
 					};
 
 					const result = await client.insights({ projectId: testProjectId }).create({
@@ -946,7 +935,6 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 							},
 						},
 					},
-					saved: true,
 					favorited: false,
 				};
 
@@ -995,7 +983,6 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 							},
 						},
 					},
-					saved: true,
 					favorited: false,
 				};
 
@@ -1050,7 +1037,6 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 							},
 						},
 					},
-					saved: true,
 					favorited: false,
 				};
 

--- a/typescript/tests/api/client.integration.test.ts
+++ b/typescript/tests/api/client.integration.test.ts
@@ -1,5 +1,19 @@
 import { ApiClient } from "@/api/client";
+import type { CreateInsightInput } from "@/schema/insights";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+// Helper function for detailed API logging
+const logApiResponse = (testName: string, success: boolean, data?: any, error?: any) => {
+	console.log(`[${testName}] API Response:`, {
+		success,
+		...(success
+			? { data: JSON.stringify(data, null, 2) }
+			: {
+					error: error?.message,
+					fullError: JSON.stringify(error, null, 2),
+				}),
+	});
+};
 
 const API_BASE_URL = process.env.TEST_POSTHOG_API_BASE_URL || "http://localhost:8010";
 const API_TOKEN = process.env.TEST_POSTHOG_PERSONAL_API_KEY;
@@ -352,6 +366,666 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 
 				// Delete will be handled by afterEach cleanup
 			}
+		});
+
+		describe("Trends Query Tests", () => {
+			it("should create trends insight with minimal parameters", async () => {
+				const insightData: CreateInsightInput = {
+					name: "Basic Trends Test",
+					query: {
+						kind: "InsightVizNode",
+						source: {
+							kind: "TrendsQuery",
+							series: [
+								{
+									kind: "EventsNode",
+									event: "$pageview",
+									math: "total",
+								},
+							],
+							properties: [],
+							filterTestAccounts: false,
+							interval: "day",
+						},
+					},
+					saved: true,
+					favorited: false,
+				};
+
+				const result = await client.insights({ projectId: testProjectId }).create({
+					data: insightData,
+				});
+
+				logApiResponse(
+					"Basic Trends",
+					result.success,
+					result.success ? result.data : undefined,
+					result.success ? undefined : (result as any).error,
+				);
+
+				expect(result.success).toBe(true);
+				if (result.success) {
+					createdResources.insights.push(result.data.id);
+				}
+			});
+
+			it("should create trends insight with all display types", async () => {
+				const displayTypes = [
+					"ActionsLineGraph",
+					"ActionsTable",
+					"ActionsPie",
+					"ActionsBar",
+					"ActionsBarValue",
+					"WorldMap",
+					"BoldNumber",
+				] as const;
+
+				for (const display of displayTypes) {
+					const insightData: CreateInsightInput = {
+						name: `Trends Display - ${display}`,
+						query: {
+							kind: "InsightVizNode",
+							source: {
+								kind: "TrendsQuery",
+								series: [
+									{
+										kind: "EventsNode",
+										event: "$pageview",
+										math: "total",
+									},
+								],
+								trendsFilter: {
+									display,
+									showLegend: true,
+								},
+								properties: [],
+								filterTestAccounts: true,
+								interval: "day",
+							},
+						},
+						favorited: false,
+						saved: true,
+					};
+
+					const result = await client.insights({ projectId: testProjectId }).create({
+						data: insightData,
+					});
+
+					logApiResponse(
+						`Trends ${display}`,
+						result.success,
+						result.success ? result.data : undefined,
+						result.success ? undefined : (result as any).error,
+					);
+
+					expect(result.success).toBe(true);
+					if (result.success) {
+						createdResources.insights.push(result.data.id);
+					}
+				}
+			});
+
+			it("should create trends insight with breakdowns", async () => {
+				const breakdownTypes = ["event", "person"] as const;
+
+				for (const breakdownType of breakdownTypes) {
+					const insightData: CreateInsightInput = {
+						name: `Trends Breakdown - ${breakdownType}`,
+						query: {
+							kind: "InsightVizNode",
+							source: {
+								kind: "TrendsQuery",
+								series: [
+									{
+										kind: "EventsNode",
+										event: "$pageview",
+										math: "total",
+									},
+								],
+								breakdownFilter: {
+									breakdown_type: breakdownType,
+									breakdown:
+										breakdownType === "event" ? "$current_url" : "$browser",
+									breakdown_limit: 10,
+								},
+								properties: [],
+								filterTestAccounts: true,
+								interval: "day",
+							},
+						},
+						favorited: false,
+						saved: true,
+					};
+
+					const result = await client.insights({ projectId: testProjectId }).create({
+						data: insightData,
+					});
+
+					logApiResponse(
+						`Trends Breakdown ${breakdownType}`,
+						result.success,
+						result.success ? result.data : undefined,
+						result.success ? undefined : (result as any).error,
+					);
+
+					expect(result.success).toBe(true);
+					if (result.success) {
+						createdResources.insights.push(result.data.id);
+					}
+				}
+			});
+
+			it("should create trends insight with different intervals", async () => {
+				const intervals = ["hour", "day", "week", "month"] as const;
+
+				for (const interval of intervals) {
+					const insightData: CreateInsightInput = {
+						name: `Trends Interval - ${interval}`,
+						query: {
+							kind: "InsightVizNode",
+							source: {
+								kind: "TrendsQuery",
+								dateRange: {
+									date_from: "-30d",
+									date_to: null,
+								},
+								interval,
+								series: [
+									{
+										kind: "EventsNode",
+										event: "$pageview",
+										math: "total",
+									},
+								],
+								properties: [],
+								filterTestAccounts: true,
+							},
+						},
+						favorited: false,
+						saved: true,
+					};
+
+					const result = await client.insights({ projectId: testProjectId }).create({
+						data: insightData,
+					});
+
+					logApiResponse(
+						`Trends Interval ${interval}`,
+						result.success,
+						result.success ? result.data : undefined,
+						result.success ? undefined : (result as any).error,
+					);
+
+					expect(result.success).toBe(true);
+					if (result.success) {
+						createdResources.insights.push(result.data.id);
+					}
+				}
+			});
+
+			it("should create trends insight with compare filter", async () => {
+				const insightData: CreateInsightInput = {
+					name: "Trends Compare Test",
+					query: {
+						kind: "InsightVizNode",
+						source: {
+							kind: "TrendsQuery",
+							series: [
+								{
+									kind: "EventsNode",
+									event: "$pageview",
+									math: "total",
+								},
+							],
+							compareFilter: {
+								compare: true,
+								compare_to: "-1w",
+							},
+							properties: [],
+							filterTestAccounts: false,
+							interval: "day",
+						},
+					},
+					favorited: false,
+					saved: true,
+				};
+
+				const result = await client.insights({ projectId: testProjectId }).create({
+					data: insightData,
+				});
+
+				logApiResponse(
+					"Trends Compare",
+					result.success,
+					result.success ? result.data : undefined,
+					result.success ? undefined : (result as any).error,
+				);
+
+				expect(result.success).toBe(true);
+				if (result.success) {
+					createdResources.insights.push(result.data.id);
+				}
+			});
+
+			it("should create trends insight with property filters", async () => {
+				const insightData: CreateInsightInput = {
+					name: "Trends Property Filters",
+					query: {
+						kind: "InsightVizNode",
+						source: {
+							kind: "TrendsQuery",
+							series: [
+								{
+									kind: "EventsNode",
+									event: "$pageview",
+									math: "total",
+									properties: [
+										{
+											key: "$browser",
+											value: ["Chrome", "Safari"],
+											operator: "exact",
+											type: "event",
+										},
+									],
+								},
+							],
+							properties: [
+								{
+									key: "$current_url",
+									value: "/dashboard",
+									operator: "icontains",
+									type: "event",
+								},
+							],
+							filterTestAccounts: false,
+							interval: "day",
+						},
+					},
+					favorited: false,
+					saved: true,
+				};
+
+				const result = await client.insights({ projectId: testProjectId }).create({
+					data: insightData,
+				});
+
+				logApiResponse(
+					"Trends Property Filter",
+					result.success,
+					result.success ? result.data : undefined,
+					result.success ? undefined : (result as any).error,
+				);
+
+				expect(result.success).toBe(true);
+				if (result.success) {
+					createdResources.insights.push(result.data.id);
+				}
+			});
+		});
+
+		describe("Funnels Query Tests", () => {
+			it("should create funnel insight with minimal parameters", async () => {
+				const insightData: CreateInsightInput = {
+					name: "Basic Funnel Test",
+					query: {
+						kind: "InsightVizNode",
+						source: {
+							kind: "FunnelsQuery",
+							series: [
+								{
+									kind: "EventsNode",
+									event: "$pageview",
+									math: "total",
+									order: 0,
+								},
+								{
+									kind: "EventsNode",
+									event: "button_clicked",
+									math: "total",
+									order: 1,
+								},
+							],
+							properties: [],
+							filterTestAccounts: false,
+						},
+					},
+					favorited: false,
+					saved: true,
+				};
+
+				const result = await client.insights({ projectId: testProjectId }).create({
+					data: insightData,
+				});
+
+				logApiResponse(
+					"Basic Funnel",
+					result.success,
+					result.success ? result.data : undefined,
+					result.success ? undefined : (result as any).error,
+				);
+
+				expect(result.success).toBe(true);
+				if (result.success) {
+					createdResources.insights.push(result.data.id);
+				}
+			});
+
+			it("should create funnel insight with different layouts and order types", async () => {
+				const configs = [
+					{ layout: "horizontal" as const, orderType: "ordered" as const },
+					{ layout: "vertical" as const, orderType: "unordered" as const },
+					{ layout: "vertical" as const, orderType: "strict" as const },
+				];
+
+				for (const config of configs) {
+					const insightData: CreateInsightInput = {
+						name: `Funnel ${config.layout} ${config.orderType}`,
+						query: {
+							kind: "InsightVizNode",
+							source: {
+								kind: "FunnelsQuery",
+								series: [
+									{
+										kind: "EventsNode",
+										event: "$pageview",
+										math: "total",
+										order: 0,
+									},
+									{
+										kind: "EventsNode",
+										event: "button_clicked",
+										math: "total",
+										order: 1,
+									},
+								],
+								funnelsFilter: {
+									layout: config.layout,
+									funnelOrderType: config.orderType,
+									funnelWindowInterval: 7,
+									funnelWindowIntervalUnit: "day",
+								},
+								properties: [],
+								filterTestAccounts: false,
+							},
+						},
+						favorited: false,
+						saved: true,
+					};
+
+					const result = await client.insights({ projectId: testProjectId }).create({
+						data: insightData,
+					});
+
+					logApiResponse(
+						`Funnel ${config.layout} ${config.orderType}`,
+						result.success,
+						result.success ? result.data : undefined,
+						result.success ? undefined : (result as any).error,
+					);
+
+					expect(result.success).toBe(true);
+					if (result.success) {
+						createdResources.insights.push(result.data.id);
+					}
+				}
+			});
+
+			it("should create funnel insight with breakdown attribution", async () => {
+				const attributionTypes = ["first_touch", "last_touch", "all_events"] as const;
+
+				for (const attribution of attributionTypes) {
+					const insightData: CreateInsightInput = {
+						name: `Funnel Attribution - ${attribution}`,
+						query: {
+							kind: "InsightVizNode",
+							source: {
+								kind: "FunnelsQuery",
+								series: [
+									{
+										kind: "EventsNode",
+										event: "$pageview",
+										math: "total",
+										order: 0,
+									},
+									{
+										kind: "EventsNode",
+										event: "button_clicked",
+										math: "total",
+										order: 1,
+									},
+								],
+								breakdownFilter: {
+									breakdown_type: "event",
+									breakdown: "$browser",
+									breakdown_limit: 5,
+								},
+								funnelsFilter: {
+									breakdownAttributionType: attribution,
+								},
+								properties: [],
+								filterTestAccounts: false,
+							},
+						},
+						favorited: false,
+						saved: true,
+					};
+
+					const result = await client.insights({ projectId: testProjectId }).create({
+						data: insightData,
+					});
+
+					logApiResponse(
+						`Funnel Attribution ${attribution}`,
+						result.success,
+						result.success ? result.data : undefined,
+						result.success ? undefined : (result as any).error,
+					);
+
+					expect(result.success).toBe(true);
+					if (result.success) {
+						createdResources.insights.push(result.data.id);
+					}
+				}
+			});
+
+			it("should create funnel insight with conversion window", async () => {
+				const windowUnits = ["minute", "hour", "day", "week", "month"] as const;
+
+				for (const unit of windowUnits) {
+					const insightData: CreateInsightInput = {
+						name: `Funnel Window - ${unit}`,
+						query: {
+							kind: "InsightVizNode",
+							source: {
+								kind: "FunnelsQuery",
+								series: [
+									{
+										kind: "EventsNode",
+										event: "$pageview",
+										math: "total",
+										order: 0,
+									},
+									{
+										kind: "EventsNode",
+										event: "button_clicked",
+										math: "total",
+										order: 1,
+									},
+								],
+								funnelsFilter: {
+									funnelWindowInterval:
+										unit === "minute" ? 30 : unit === "hour" ? 2 : 7,
+									funnelWindowIntervalUnit: unit,
+								},
+								properties: [],
+								filterTestAccounts: false,
+							},
+						},
+						favorited: false,
+						saved: true,
+					};
+
+					const result = await client.insights({ projectId: testProjectId }).create({
+						data: insightData,
+					});
+
+					logApiResponse(
+						`Funnel Window ${unit}`,
+						result.success,
+						result.success ? result.data : undefined,
+						result.success ? undefined : (result as any).error,
+					);
+
+					expect(result.success).toBe(true);
+					if (result.success) {
+						createdResources.insights.push(result.data.id);
+					}
+				}
+			});
+		});
+
+		describe("HogQL Query Tests", () => {
+			it("should create HogQL insight with basic query", async () => {
+				const insightData: CreateInsightInput = {
+					name: "Basic HogQL Test",
+					query: {
+						kind: "DataVisualizationNode" as const,
+						source: {
+							kind: "HogQLQuery" as const,
+							query: "SELECT count() as total_events FROM events WHERE event = '$pageview'",
+							filters: {
+								dateRange: {
+									date_from: "-7d",
+									date_to: null,
+								},
+								filterTestAccounts: true,
+							},
+						},
+					},
+					saved: true,
+					favorited: false,
+				};
+
+				const result = await client.insights({ projectId: testProjectId }).create({
+					data: insightData,
+				});
+
+				logApiResponse(
+					"Basic HogQL",
+					result.success,
+					result.success ? result.data : undefined,
+					result.success ? undefined : (result as any).error,
+				);
+
+				expect(result.success).toBe(true);
+				if (result.success) {
+					createdResources.insights.push(result.data.id);
+				}
+			});
+
+			it("should create HogQL insight with aggregation query", async () => {
+				const insightData: CreateInsightInput = {
+					name: "HogQL Aggregation Test",
+					query: {
+						kind: "DataVisualizationNode" as const,
+						source: {
+							kind: "HogQLQuery" as const,
+							query: `
+								SELECT 
+									toDate(timestamp) as date,
+									count() as events,
+									uniq(distinct_id) as unique_users,
+									avg(toFloat(JSONExtractString(properties, '$screen_width'))) as avg_screen_width
+								FROM events 
+								WHERE event = '$pageview' 
+									AND timestamp >= now() - INTERVAL 30 DAY
+								GROUP BY date 
+								ORDER BY date
+							`,
+							filters: {
+								dateRange: {
+									date_from: "-30d",
+									date_to: null,
+								},
+								filterTestAccounts: true,
+							},
+						},
+					},
+					saved: true,
+					favorited: false,
+				};
+
+				const result = await client.insights({ projectId: testProjectId }).create({
+					data: insightData,
+				});
+
+				logApiResponse(
+					"HogQL Aggregation",
+					result.success,
+					result.success ? result.data : undefined,
+					result.success ? undefined : (result as any).error,
+				);
+
+				expect(result.success).toBe(true);
+				if (result.success) {
+					createdResources.insights.push(result.data.id);
+				}
+			});
+
+			it("should create HogQL insight with property filters", async () => {
+				const insightData: CreateInsightInput = {
+					name: "HogQL Property Filter Test",
+					query: {
+						kind: "DataVisualizationNode" as const,
+						source: {
+							kind: "HogQLQuery" as const,
+							query: `
+								SELECT 
+									JSONExtractString(properties, '$browser') as browser,
+									count() as pageviews
+								FROM events 
+								WHERE event = '$pageview'
+								GROUP BY browser
+								ORDER BY pageviews DESC
+								LIMIT 10
+							`,
+							filters: {
+								dateRange: {
+									date_from: "-30d",
+									date_to: null,
+								},
+								filterTestAccounts: true,
+								properties: [
+									{
+										key: "$browser",
+										value: "Chrome",
+										operator: "exact",
+										type: "event",
+									},
+								],
+							},
+						},
+					},
+					saved: true,
+					favorited: false,
+				};
+
+				const result = await client.insights({ projectId: testProjectId }).create({
+					data: insightData,
+				});
+
+				logApiResponse(
+					"HogQL Property Filter",
+					result.success,
+					result.success ? result.data : undefined,
+					result.success ? undefined : (result as any).error,
+				);
+
+				expect(result.success).toBe(true);
+				if (result.success) {
+					createdResources.insights.push(result.data.id);
+				}
+			});
 		});
 	});
 

--- a/typescript/tests/api/client.integration.test.ts
+++ b/typescript/tests/api/client.integration.test.ts
@@ -676,13 +676,11 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 									kind: "EventsNode",
 									event: "$pageview",
 									math: "total",
-									order: 0,
 								},
 								{
 									kind: "EventsNode",
 									event: "button_clicked",
 									math: "total",
-									order: 1,
 								},
 							],
 							properties: [],
@@ -729,13 +727,11 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 										kind: "EventsNode",
 										event: "$pageview",
 										math: "total",
-										order: 0,
 									},
 									{
 										kind: "EventsNode",
 										event: "button_clicked",
 										math: "total",
-										order: 1,
 									},
 								],
 								funnelsFilter: {
@@ -785,13 +781,11 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 										kind: "EventsNode",
 										event: "$pageview",
 										math: "total",
-										order: 0,
 									},
 									{
 										kind: "EventsNode",
 										event: "button_clicked",
 										math: "total",
-										order: 1,
 									},
 								],
 								breakdownFilter: {
@@ -843,13 +837,11 @@ describe("API Client Integration Tests", { concurrent: false }, () => {
 										kind: "EventsNode",
 										event: "$pageview",
 										math: "total",
-										order: 0,
 									},
 									{
 										kind: "EventsNode",
 										event: "button_clicked",
 										math: "total",
-										order: 1,
 									},
 								],
 								funnelsFilter: {


### PR DESCRIPTION
We currently only support creating HogQL insights using the `get-sql-insight` tool, we want to make this more flexible so users can build their own agents rather than always relying on ours to decide what insight to build.

This adds Trends & Funnel queries that support a subset of the syntax supported in the app. I've tried to strike a balance between keeping it simple enough for the LLM to have a chance of getting it right, but including as much useful options as possible. Aim would be to cover 90%+ of queries, but not 100% of options, as the very specific insights are most likely to be created in the app and not handed off to an LLM that might screw it up.

It also enforces validation before tool inputs (which we were not doing previously), and does not report errors for invalid inputs, but records if an `mcp tool call` event had a valid input or not.

