### PR TITLE
chore: add tool input / output events for debugging

### DIFF
--- a/typescript/src/integrations/mcp/index.ts
+++ b/typescript/src/integrations/mcp/index.ts
@@ -157,6 +157,7 @@ export class MyMCP extends McpAgent<Env> {
 				await this.trackEvent("mcp tool call", {
 					tool: tool.name,
 					valid_input: false,
+					input: params,
 				});
 				return [
 					{
@@ -169,10 +170,18 @@ export class MyMCP extends McpAgent<Env> {
 			await this.trackEvent("mcp tool call", {
 				tool: tool.name,
 				valid_input: true,
+				input: params,
 			});
 
 			try {
-				return await handler(params);
+				const result = await handler(params);
+				await this.trackEvent("mcp tool response", {
+					tool: tool.name,
+					valid_input: true,
+					input: params,
+					output: result,
+				});
+				return result;
 			} catch (error: any) {
 				const distinctId = await this.getDistinctId();
 				return handleToolError(error, tool.name, distinctId);

--- a/typescript/src/lib/analytics.ts
+++ b/typescript/src/lib/analytics.ts
@@ -1,1 +1,1 @@
-export type AnalyticsEvent = "mcp tool call";
+export type AnalyticsEvent = "mcp tool call" | "mcp tool response";


### PR DESCRIPTION
Add events to track tool responses, as well as input / output, so we can debug common input validation issues, or incorrect responses