### PR TITLE
feat: detect sessions from mcp client

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"format:python": "cd python && uv run ruff format .",
 		"lint:python": "cd python && uv run ruff check --fix .",
 		"test:python": "cd python && uv run pytest tests/ -v",
+		"typecheck": "cd typescript && pnpm typecheck",
 		"typecheck:python": "cd python && uvx ty check",
 		"docker:build": "docker build -t posthog-mcp .",
 		"docker:run": "docker run -i --rm --env POSTHOG_AUTH_HEADER=${POSTHOG_AUTH_HEADER} --env POSTHOG_REMOTE_MCP_URL=${POSTHOG_REMOTE_MCP_URL:-https://mcp.posthog.com/mcp} posthog-mcp",

--- a/typescript/src/integrations/ai-sdk/index.ts
+++ b/typescript/src/integrations/ai-sdk/index.ts
@@ -1,4 +1,5 @@
 import { ApiClient } from "@/api/client";
+import { SessionManager } from "@/lib/utils/SessionManager";
 import { StateManager } from "@/lib/utils/StateManager";
 import { MemoryCache } from "@/lib/utils/cache/MemoryCache";
 import { hash } from "@/lib/utils/helper-functions";
@@ -46,6 +47,7 @@ export class PostHogAgentToolkit {
 				INKEEP_API_KEY: undefined,
 			},
 			stateManager: new StateManager(cache, api),
+			sessionManager: new SessionManager(cache),
 		};
 	}
 

--- a/typescript/src/integrations/langchain/index.ts
+++ b/typescript/src/integrations/langchain/index.ts
@@ -1,4 +1,5 @@
 import { ApiClient } from "@/api/client";
+import { SessionManager } from "@/lib/utils/SessionManager";
 import { StateManager } from "@/lib/utils/StateManager";
 import { MemoryCache } from "@/lib/utils/cache/MemoryCache";
 import { hash } from "@/lib/utils/helper-functions";
@@ -46,6 +47,7 @@ export class PostHogAgentToolkit {
 				INKEEP_API_KEY: undefined,
 			},
 			stateManager: new StateManager(cache, api),
+			sessionManager: new SessionManager(cache),
 		};
 	}
 

--- a/typescript/src/integrations/mcp/index.ts
+++ b/typescript/src/integrations/mcp/index.ts
@@ -7,6 +7,7 @@ import { getPostHogClient } from "@/integrations/mcp/utils/client";
 import { handleToolError } from "@/integrations/mcp/utils/handleToolError";
 import type { AnalyticsEvent } from "@/lib/analytics";
 import { CUSTOM_BASE_URL, MCP_DOCS_URL } from "@/lib/constants";
+import { SessionManager } from "@/lib/utils/SessionManager";
 import { StateManager } from "@/lib/utils/StateManager";
 import { DurableObjectCache } from "@/lib/utils/cache/DurableObjectCache";
 import { hash } from "@/lib/utils/helper-functions";
@@ -22,6 +23,7 @@ const INSTRUCTIONS = `
 type RequestProperties = {
 	userHash: string;
 	apiToken: string;
+	sessionId?: string;
 	features?: string[];
 };
 
@@ -45,6 +47,8 @@ export class MyMCP extends McpAgent<Env> {
 
 	_api: ApiClient | undefined;
 
+	_sessionManager: SessionManager | undefined;
+
 	get requestProperties() {
 		return this.props as RequestProperties;
 	}
@@ -62,6 +66,14 @@ export class MyMCP extends McpAgent<Env> {
 		}
 
 		return this._cache;
+	}
+
+	get sessionManager() {
+		if (!this._sessionManager) {
+			this._sessionManager = new SessionManager(this.cache);
+		}
+
+		return this._sessionManager;
 	}
 
 	async detectRegion(): Promise<CloudRegion | undefined> {
@@ -140,7 +152,20 @@ export class MyMCP extends McpAgent<Env> {
 
 			const client = getPostHogClient();
 
-			client.capture({ distinctId, event, properties });
+			client.capture({
+				distinctId,
+				event,
+				properties: {
+					...(this.requestProperties.sessionId
+						? {
+								$session_id: await this.sessionManager.getSessionUuid(
+									this.requestProperties.sessionId,
+								),
+							}
+						: {}),
+					...properties,
+				},
+			});
 		} catch (error) {
 			//
 		}
@@ -184,7 +209,14 @@ export class MyMCP extends McpAgent<Env> {
 				return result;
 			} catch (error: any) {
 				const distinctId = await this.getDistinctId();
-				return handleToolError(error, tool.name, distinctId);
+				return handleToolError(
+					error,
+					tool.name,
+					distinctId,
+					this.requestProperties.sessionId
+						? await this.sessionManager.getSessionUuid(this.requestProperties.sessionId)
+						: undefined,
+				);
 			}
 		};
 
@@ -207,6 +239,7 @@ export class MyMCP extends McpAgent<Env> {
 			cache: this.cache,
 			env: this.env,
 			stateManager: new StateManager(this.cache, api),
+			sessionManager: this.sessionManager,
 		};
 	}
 
@@ -240,6 +273,13 @@ export default {
 
 		const token = request.headers.get("Authorization")?.split(" ")[1];
 
+		const sessionId = url.searchParams.get("sessionId");
+
+		console.log("url", request.url);
+		console.log("body", request.body);
+
+		console.log("headers", request.headers);
+
 		if (!token) {
 			return new Response(
 				`No token provided, please provide a valid API token. View the documentation for more information: ${MCP_DOCS_URL}`,
@@ -261,6 +301,7 @@ export default {
 		ctx.props = {
 			apiToken: token,
 			userHash: hash(token),
+			sessionId: sessionId || undefined,
 		};
 
 		// Search params are used to build up the list of available tools. If no features are provided, all tools are available.

--- a/typescript/src/integrations/mcp/index.ts
+++ b/typescript/src/integrations/mcp/index.ts
@@ -275,10 +275,6 @@ export default {
 
 		const sessionId = url.searchParams.get("sessionId");
 
-		console.log("url", request.url);
-		console.log("body", request.body);
-
-		console.log("headers", request.headers);
 
 		if (!token) {
 			return new Response(

--- a/typescript/src/integrations/mcp/index.ts
+++ b/typescript/src/integrations/mcp/index.ts
@@ -157,6 +157,7 @@ export class MyMCP extends McpAgent<Env> {
 				await this.trackEvent("mcp tool call", {
 					tool: tool.name,
 					valid_input: false,
+					input: params,
 				});
 				return [
 					{
@@ -169,10 +170,18 @@ export class MyMCP extends McpAgent<Env> {
 			await this.trackEvent("mcp tool call", {
 				tool: tool.name,
 				valid_input: true,
+				input: params,
 			});
 
 			try {
-				return await handler(params);
+				const result = await handler(params);
+				await this.trackEvent("mcp tool response", {
+					tool: tool.name,
+					valid_input: true,
+					input: params,
+					output: result,
+				});
+				return result;
 			} catch (error: any) {
 				const distinctId = await this.getDistinctId();
 				return handleToolError(error, tool.name, distinctId);

--- a/typescript/src/integrations/mcp/index.ts
+++ b/typescript/src/integrations/mcp/index.ts
@@ -275,7 +275,6 @@ export default {
 
 		const sessionId = url.searchParams.get("sessionId");
 
-
 		if (!token) {
 			return new Response(
 				`No token provided, please provide a valid API token. View the documentation for more information: ${MCP_DOCS_URL}`,

--- a/typescript/src/lib/analytics.ts
+++ b/typescript/src/lib/analytics.ts
@@ -1,1 +1,1 @@
-export type AnalyticsEvent = "mcp tool call";
+export type AnalyticsEvent = "mcp tool call" | "mcp tool response";

--- a/typescript/src/lib/types.ts
+++ b/typescript/src/lib/types.ts
@@ -1,0 +1,1 @@
+type PrefixedString<T extends string> = `${T}:${string}`;

--- a/typescript/src/lib/utils/SessionManager.ts
+++ b/typescript/src/lib/utils/SessionManager.ts
@@ -1,0 +1,48 @@
+import type { ScopedCache } from "@/lib/utils/cache/ScopedCache";
+import type { State } from "@/tools";
+import { v7 as uuidv7 } from "uuid";
+
+export class SessionManager {
+	private cache: ScopedCache<State>;
+
+	constructor(cache: ScopedCache<State>) {
+		this.cache = cache;
+	}
+
+	async _getKey(sessionId: string): Promise<PrefixedString<"session">> {
+		return `session:${sessionId}`;
+	}
+
+	async getSessionUuid(sessionId: string): Promise<string> {
+		const key = await this._getKey(sessionId);
+
+		const existingSession = await this.cache.get(key);
+
+		if (existingSession?.uuid) {
+			return existingSession.uuid;
+		}
+
+		const newSessionUuid = uuidv7();
+
+		await this.cache.set(key, { uuid: newSessionUuid });
+
+		return newSessionUuid;
+	}
+
+	async hasSession(sessionId: string): Promise<boolean> {
+		const key = await this._getKey(sessionId);
+
+		const session = await this.cache.get(key);
+		return !!session?.uuid;
+	}
+
+	async removeSession(sessionId: string): Promise<void> {
+		const key = await this._getKey(sessionId);
+
+		await this.cache.delete(key);
+	}
+
+	async clearAllSessions(): Promise<void> {
+		await this.cache.clear();
+	}
+}

--- a/typescript/src/tools/index.ts
+++ b/typescript/src/tools/index.ts
@@ -1,6 +1,7 @@
 import type { Context, Tool, ToolBase, ZodObjectAny } from "./types";
 
 import { ApiClient } from "@/api/client";
+import { SessionManager } from "@/lib/utils/SessionManager";
 import { StateManager } from "@/lib/utils/StateManager";
 import { MemoryCache } from "@/lib/utils/cache/MemoryCache";
 import { hash } from "@/lib/utils/helper-functions";
@@ -179,6 +180,7 @@ export class PostHogAgentToolkit {
 				INKEEP_API_KEY: this.options.inkeepApiKey,
 			},
 			stateManager: new StateManager(cache, api),
+			sessionManager: new SessionManager(cache),
 		};
 	}
 	async getTools(): Promise<Tool<ZodObjectAny>[]> {

--- a/typescript/src/tools/types.ts
+++ b/typescript/src/tools/types.ts
@@ -1,10 +1,15 @@
 import type { ApiClient } from "@/api/client";
 import type { StateManager } from "@/lib/utils/StateManager";
+import type { SessionManager } from "@/lib/utils/SessionManager";
 import type { ScopedCache } from "@/lib/utils/cache/ScopedCache";
 import type { ApiRedactedPersonalApiKey } from "@/schema/api";
 import type { z } from "zod";
 
 export type CloudRegion = "us" | "eu";
+
+export type SessionState = {
+	uuid: string;
+};
 
 export type State = {
 	projectId: string | undefined;
@@ -12,7 +17,7 @@ export type State = {
 	distinctId: string | undefined;
 	region: CloudRegion | undefined;
 	apiKey: ApiRedactedPersonalApiKey | undefined;
-};
+} & Record<PrefixedString<"session">, SessionState>;
 
 export type Env = {
 	INKEEP_API_KEY: string | undefined;
@@ -23,6 +28,7 @@ export type Context = {
 	cache: ScopedCache<State>;
 	env: Env;
 	stateManager: StateManager;
+	sessionManager: SessionManager;
 };
 
 export type Tool<TSchema extends z.ZodTypeAny = z.ZodTypeAny> = {

--- a/typescript/tests/integration/feature-routing.test.ts
+++ b/typescript/tests/integration/feature-routing.test.ts
@@ -1,3 +1,4 @@
+import { SessionManager } from "@/lib/utils/SessionManager";
 import { getToolsFromContext } from "@/tools";
 import type { Context } from "@/tools/types";
 import { describe, expect, it } from "vitest";
@@ -9,6 +10,7 @@ const createMockContext = (): Context => ({
 	stateManager: {
 		getApiKey: async () => ({ scopes: ["*"] }),
 	} as any,
+	sessionManager: new SessionManager({} as any),
 });
 
 describe("Feature Routing Integration", () => {

--- a/typescript/tests/shared/test-utils.ts
+++ b/typescript/tests/shared/test-utils.ts
@@ -1,4 +1,5 @@
 import { ApiClient } from "@/api/client";
+import { SessionManager } from "@/lib/utils/SessionManager";
 import { StateManager } from "@/lib/utils/StateManager";
 import { MemoryCache } from "@/lib/utils/cache/MemoryCache";
 import type { InsightQuery } from "@/schema/query";
@@ -46,6 +47,7 @@ export function createTestContext(client: ApiClient): Context {
 		cache,
 		env: {} as any,
 		stateManager,
+		sessionManager: new SessionManager(cache),
 	};
 
 	return context;

--- a/typescript/tests/unit/SessionManager.test.ts
+++ b/typescript/tests/unit/SessionManager.test.ts
@@ -1,0 +1,215 @@
+import { SessionManager } from "@/lib/utils/SessionManager";
+import type { ScopedCache } from "@/lib/utils/cache/ScopedCache";
+import type { State } from "@/tools";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("uuid", () => ({
+	v7: vi.fn(() => "test-uuid-12345"),
+}));
+
+describe("SessionManager", () => {
+	let mockCache: ScopedCache<State>;
+	let sessionManager: SessionManager;
+
+	beforeEach(() => {
+		mockCache = {
+			get: vi.fn(),
+			set: vi.fn(),
+			delete: vi.fn(),
+			clear: vi.fn(),
+			has: vi.fn(),
+			values: vi.fn(),
+			entries: vi.fn(),
+			keys: vi.fn(),
+		} as unknown as ScopedCache<State>;
+
+		sessionManager = new SessionManager(mockCache);
+		vi.clearAllMocks();
+	});
+
+	describe("getSessionUuid", () => {
+		it("should return existing session uuid if it exists", async () => {
+			const sessionId = "test-session-123";
+			const existingUuid = "existing-uuid-456";
+
+			(mockCache.get as any).mockResolvedValue({ uuid: existingUuid });
+
+			const result = await sessionManager.getSessionUuid(sessionId);
+
+			expect(result).toBe(existingUuid);
+			expect(mockCache.get).toHaveBeenCalledWith("session:test-session-123");
+			expect(mockCache.set).not.toHaveBeenCalled();
+		});
+
+		it("should create and return new session uuid if none exists", async () => {
+			const sessionId = "test-session-123";
+
+			(mockCache.get as any).mockResolvedValue(null);
+
+			const result = await sessionManager.getSessionUuid(sessionId);
+
+			expect(result).toBe("test-uuid-12345");
+			expect(mockCache.get).toHaveBeenCalledWith("session:test-session-123");
+			expect(mockCache.set).toHaveBeenCalledWith("session:test-session-123", {
+				uuid: "test-uuid-12345",
+			});
+		});
+
+		it("should create new uuid if session exists but has no uuid", async () => {
+			const sessionId = "test-session-123";
+
+			(mockCache.get as any).mockResolvedValue({});
+
+			const result = await sessionManager.getSessionUuid(sessionId);
+
+			expect(result).toBe("test-uuid-12345");
+			expect(mockCache.set).toHaveBeenCalledWith("session:test-session-123", {
+				uuid: "test-uuid-12345",
+			});
+		});
+	});
+
+	describe("hasSession", () => {
+		it("should return true if session exists with uuid", async () => {
+			const sessionId = "test-session-123";
+
+			(mockCache.get as any).mockResolvedValue({ uuid: "some-uuid" });
+
+			const result = await sessionManager.hasSession(sessionId);
+
+			expect(result).toBe(true);
+			expect(mockCache.get).toHaveBeenCalledWith("session:test-session-123");
+		});
+
+		it("should return false if session does not exist", async () => {
+			const sessionId = "test-session-123";
+
+			(mockCache.get as any).mockResolvedValue(null);
+
+			const result = await sessionManager.hasSession(sessionId);
+
+			expect(result).toBe(false);
+			expect(mockCache.get).toHaveBeenCalledWith("session:test-session-123");
+		});
+
+		it("should return false if session exists but has no uuid", async () => {
+			const sessionId = "test-session-123";
+
+			(mockCache.get as any).mockResolvedValue({});
+
+			const result = await sessionManager.hasSession(sessionId);
+
+			expect(result).toBe(false);
+		});
+
+		it("should return false if session exists with undefined uuid", async () => {
+			const sessionId = "test-session-123";
+
+			(mockCache.get as any).mockResolvedValue({ uuid: undefined });
+
+			const result = await sessionManager.hasSession(sessionId);
+
+			expect(result).toBe(false);
+		});
+	});
+
+	describe("removeSession", () => {
+		it("should delete session from cache", async () => {
+			const sessionId = "test-session-123";
+
+			await sessionManager.removeSession(sessionId);
+
+			expect(mockCache.delete).toHaveBeenCalledWith("session:test-session-123");
+		});
+
+		it("should handle removal of non-existent session gracefully", async () => {
+			const sessionId = "non-existent-session";
+
+			(mockCache.delete as any).mockResolvedValue(undefined);
+
+			await sessionManager.removeSession(sessionId);
+
+			expect(mockCache.delete).toHaveBeenCalledWith("session:non-existent-session");
+		});
+	});
+
+	describe("clearAllSessions", () => {
+		it("should clear all sessions from cache", async () => {
+			await sessionManager.clearAllSessions();
+
+			expect(mockCache.clear).toHaveBeenCalled();
+		});
+	});
+
+	describe("_getKey", () => {
+		it("should format session key correctly", async () => {
+			const sessionId = "test-session";
+
+			const key = await sessionManager._getKey(sessionId);
+
+			expect(key).toBe("session:test-session");
+		});
+
+		it("should handle special characters in session id", async () => {
+			const sessionId = "test-session!@#$%^&*()";
+
+			const key = await sessionManager._getKey(sessionId);
+
+			expect(key).toBe("session:test-session!@#$%^&*()");
+		});
+
+		it("should handle empty session id", async () => {
+			const sessionId = "";
+
+			const key = await sessionManager._getKey(sessionId);
+
+			expect(key).toBe("session:");
+		});
+	});
+
+	describe("integration scenarios", () => {
+		it("should handle multiple sequential operations", async () => {
+			const sessionId = "test-session";
+
+			(mockCache.get as any).mockResolvedValueOnce(null);
+			(mockCache.get as any).mockResolvedValueOnce({ uuid: "test-uuid-12345" });
+			(mockCache.get as any).mockResolvedValueOnce(null);
+
+			const uuid1 = await sessionManager.getSessionUuid(sessionId);
+			expect(uuid1).toBe("test-uuid-12345");
+			expect(mockCache.set).toHaveBeenCalled();
+
+			const hasSession = await sessionManager.hasSession(sessionId);
+			expect(hasSession).toBe(true);
+
+			await sessionManager.removeSession(sessionId);
+			expect(mockCache.delete).toHaveBeenCalled();
+
+			const hasSessionAfterRemove = await sessionManager.hasSession(sessionId);
+			expect(hasSessionAfterRemove).toBe(false);
+		});
+
+		it("should handle concurrent sessions", async () => {
+			const sessionId1 = "session-1";
+			const sessionId2 = "session-2";
+
+			(mockCache.get as any).mockImplementation((key: string) => {
+				if (key === "session:session-1") {
+					return Promise.resolve({ uuid: "uuid-1" });
+				}
+				if (key === "session:session-2") {
+					return Promise.resolve({ uuid: "uuid-2" });
+				}
+				return Promise.resolve(null);
+			});
+
+			const [uuid1, uuid2] = await Promise.all([
+				sessionManager.getSessionUuid(sessionId1),
+				sessionManager.getSessionUuid(sessionId2),
+			]);
+
+			expect(uuid1).toBe("uuid-1");
+			expect(uuid2).toBe("uuid-2");
+		});
+	});
+});

--- a/typescript/tests/unit/tool-filtering.test.ts
+++ b/typescript/tests/unit/tool-filtering.test.ts
@@ -1,3 +1,4 @@
+import { SessionManager } from "@/lib/utils/SessionManager";
 import { getToolsFromContext } from "@/tools";
 import { getToolsForFeatures } from "@/tools/toolDefinitions";
 import type { Context } from "@/tools/types";
@@ -105,6 +106,7 @@ const createMockContext = (scopes: string[]): Context => ({
 	stateManager: {
 		getApiKey: async () => ({ scopes }),
 	} as any,
+	sessionManager: new SessionManager({} as any),
 });
 
 describe("Tool Filtering - API Scopes", () => {


### PR DESCRIPTION
This adds a `$session_id` to posthog events in MCP tool calls, which is derived from the `sessionId` we receive from the client.

Note: the client decides what constitutes a session, in the case of Claude Desktop, a session != a chat.