### PR TITLE
fix: update inkeep model

### DIFF
--- a/typescript/src/inkeepApi.ts
+++ b/typescript/src/inkeepApi.ts
@@ -18,7 +18,7 @@ export async function docsSearch(apiKey: string, userQuery: string): Promise<str
 			Authorization: `Bearer ${apiKey}`,
 		},
 		body: JSON.stringify({
-			model: "inkeep-context-gpt-4o",
+			model: "inkeep-qa-expert",
 			messages: [{ role: "user", content: userQuery }],
 		}),
 	});


### PR DESCRIPTION
We want to always use the latest possible inkeep model. This PR updates it to `inkeep-qa-expert`.